### PR TITLE
Normalize tileType casing

### DIFF
--- a/opentopo/opentopo_opentopomap.xml
+++ b/opentopo/opentopo_opentopomap.xml
@@ -3,7 +3,7 @@
     <name>OpenTopo - Opentopomap</name>
     <minZoom>1</minZoom>
     <maxZoom>17</maxZoom>
-    <tileType>PNG</tileType>
+    <tileType>png</tileType>
     <tileUpdate>IfNoneMatch</tileUpdate>
     <serverParts>a b c</serverParts>
     <url>https://{$serverpart}.tile.opentopomap.org/{$z}/{$x}/{$y}.png</url>


### PR DESCRIPTION
## Summary
- correct the tile type to lowercase in `opentopo_opentopomap.xml`
- verify that no other map sources use uppercase tile types

## Testing
- `grep -n "<tileType>[A-Z]" -r | wc -l`