### PR TITLE
Fix release asset upload

### DIFF
--- a/.github/workflows/zip_release.yml
+++ b/.github/workflows/zip_release.yml
@@ -1,8 +1,7 @@
 on:
-  push:
-    # Sequence of patterns matched against refs/tags
-    tags:
-    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+  release:
+    types:
+      - published
 
 name: Upload Release Asset
 
@@ -13,26 +12,18 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.release.tag_name }}
       - name: Build project # This would actually build your project, using zip for an example artifact
         run: |
-          zip -r ATAK-Maps . -i \*.xml
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
+          zip -r ATAK-Maps.zip . -i \*.xml
       - name: Upload Release Asset
-        id: upload-release-asset 
+        id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          upload_url: ${{ github.event.release.upload_url }}
           asset_path: ./ATAK-Maps.zip
           asset_name: ATAK-Maps.zip
           asset_content_type: application/zip


### PR DESCRIPTION
## Summary
- fix release workflow so it uploads the ZIP when a release is published

## Testing
- `pip install yamllint` *(fails: Could not find a version that satisfies the requirement yamllint)*