### PR TITLE
feat: Add Bing Satellite (aerial-only) map source

### DIFF
--- a/Bing/Bing_Satellite.xml
+++ b/Bing/Bing_Satellite.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<customMapSource>
+    <name>Bing - Satellite</name>
+    <minZoom>0</minZoom>
+    <maxZoom>20</maxZoom>
+    <tileType>jpg</tileType>
+    <url>https://ecn.t2.tiles.virtualearth.net/tiles/a{$q}?g=761&amp;mkt=en-us</url>
+    <tileUpdate>None</tileUpdate>
+    <backgroundColor>#000000</backgroundColor>
+    <ignoreErrors>false</ignoreErrors>
+    <serverParts></serverParts>
+</customMapSource>


### PR DESCRIPTION
## Summary
Adds a satellite-only imagery layer from Bing Maps without road overlays.

## Changes
- Created `Bing/Bing_Satellite.xml` using aerial tiles (prefix 'a') instead of hybrid tiles (prefix 'h')
- Provides pure satellite imagery for users who don't want road overlays

## Resolves
Closes #64

## Testing
Tested in ATAK - satellite imagery loads correctly without road overlays.