### PR TITLE
feat: add BLM land ownership (SMA) map sources

### DIFF
--- a/BLM/blm_land_ownership_sma.xml
+++ b/BLM/blm_land_ownership_sma.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<customMapSource>
+    <name>BLM - Land Ownership (SMA)</name>
+    <minZoom>1</minZoom>
+    <maxZoom>14</maxZoom>
+    <tileType>jpg</tileType>
+    <!--
+        BLM Surface Management Agency (SMA): federal/state/local land ownership
+        for the United States. Yellow = BLM, green = USFS, lavender = NPS,
+        orange = BIA, light blue = state, white = private/unknown.
+        Data: Bureau of Land Management, public domain. Cache tops out at
+        zoom 14 (~10 m/px); tiles are MIXED format (jpg where opaque, png
+        where transparent).
+    -->
+    <url>https://gis.blm.gov/arcgis/rest/services/lands/BLM_Natl_SMA_Cached_with_PriUnk/MapServer/tile/{$z}/{$y}/{$x}</url>
+    <backgroundColor>#000000</backgroundColor>
+</customMapSource>

--- a/BLM/blm_satellite_land_ownership.xml
+++ b/BLM/blm_satellite_land_ownership.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<customMultiLayerMapSource>
+    <name>BLM - Satellite + Land Ownership</name>
+    <!--
+        Esri World Imagery with BLM Surface Management Agency land-ownership
+        colors composited on top at 50% opacity. Private/unknown land is
+        transparent in this SMA variant, so it stays clean satellite.
+        ATAK fetches both layers per tile and blends them client-side
+        (per-layer alpha via layersAlpha). maxZoom is capped at 14 on both
+        layers because the BLM cache ends there.
+        Data: Bureau of Land Management (public domain) + Esri World Imagery.
+    -->
+    <layersAlpha>1.0 0.5</layersAlpha>
+    <layers>
+        <customMapSource>
+            <name>World Imagery</name>
+            <minZoom>1</minZoom>
+            <maxZoom>14</maxZoom>
+            <tileType>jpg</tileType>
+            <url>https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{$z}/{$y}/{$x}</url>
+        </customMapSource>
+        <customMapSource>
+            <name>BLM SMA</name>
+            <minZoom>1</minZoom>
+            <maxZoom>14</maxZoom>
+            <tileType>png</tileType>
+            <url>https://gis.blm.gov/arcgis/rest/services/lands/BLM_Natl_SMA_Cached_without_PriUnk/MapServer/tile/{$z}/{$y}/{$x}</url>
+        </customMapSource>
+    </layers>
+</customMultiLayerMapSource>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ Three root element types (see `docs/xml-reference.md` for full spec):
 
 - **`customMapSource`** — TMS/XYZ tile sources (most files). Placeholders: `{$z}`, `{$x}`, `{$y}`, `{$q}` (quadkey), `{$serverpart}`
 - **`customWmsMapSource`** — OGC Web Map Service sources (basemapDE, Canada, FEMA, Poland)
-- **`customMultiLayerMapSource`** — Composite layers with per-layer opacity (not currently used in repository)
+- **`customMultiLayerMapSource`** — Composite layers with per-layer opacity (e.g. `BLM/blm_satellite_land_ownership.xml`)
 
 Schema at `schema/mobac-maps.xsd` validates all three types. Derived from ATAK's `MobacMapSourceFactory.java`.
 

--- a/GRG/grg_blm_public_lands_overlay.xml
+++ b/GRG/grg_blm_public_lands_overlay.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<customMapSource>
+    <name>GRG - BLM Public Lands Overlay</name>
+    <minZoom>1</minZoom>
+    <maxZoom>14</maxZoom>
+    <tileType>png</tileType>
+    <!--
+        BLM Surface Management Agency variant that leaves private/unknown land
+        fully transparent, so it works as an overlay above any basemap:
+        color = public (or otherwise government-managed) land, clear = private.
+        Data: Bureau of Land Management, public domain. Cache ends at zoom 14.
+    -->
+    <url>https://gis.blm.gov/arcgis/rest/services/lands/BLM_Natl_SMA_Cached_without_PriUnk/MapServer/tile/{$z}/{$y}/{$x}</url>
+    <backgroundColor>#000000</backgroundColor>
+</customMapSource>

--- a/mapvalidator/probe.py
+++ b/mapvalidator/probe.py
@@ -96,6 +96,18 @@ def build_test_urls(root: ET.Element) -> list[str]:
     Returns a list of URLs to try (first success wins).
     """
     tag = root.tag
+
+    # Multi-layer sources carry their URLs on nested layers; probe those.
+    # The flat list means the source counts as reachable when any layer
+    # responds (first success wins, matching the single-source semantics).
+    if tag == "customMultiLayerMapSource":
+        layers_el = root.find("layers")
+        urls: list[str] = []
+        if layers_el is not None:
+            for layer in layers_el:
+                urls.extend(build_test_urls(layer))
+        return urls
+
     url = root.findtext("url", "")
     if not url.strip():
         return []

--- a/mapvalidator/probe.py
+++ b/mapvalidator/probe.py
@@ -12,9 +12,8 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 
-import urllib3
-
 import requests
+import urllib3
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -266,13 +265,120 @@ def classify(
 # Source-level probing
 # ---------------------------------------------------------------------------
 
+# Worst-first severity ranking used to aggregate multi-layer sources: a
+# composite source is only as healthy as its least-healthy layer.
+_STATUS_SEVERITY = {
+    ProbeStatus.HEALTHY: 0,
+    ProbeStatus.DEGRADED: 1,
+    ProbeStatus.BLOCKED: 2,
+    ProbeStatus.DEAD: 3,
+}
+
+_ProbeTuple = tuple[int | None, str | None, bool, int]
+
+
+def _probe_url_list(test_urls: list[str]) -> tuple[_ProbeTuple, _ProbeTuple, str]:
+    """Probe a list of tile URLs with both user agents; first 200 wins.
+
+    Returns (tak_result, generic_result, url) for the winning URL (or the
+    last one tried if none returned 200).
+    """
+    best_tak: _ProbeTuple = (None, "No URLs probed", False, 0)
+    best_generic: _ProbeTuple = (None, "No URLs probed", False, 0)
+    best_url = test_urls[0]
+
+    for url in test_urls:
+        tak_result = probe_url(url, TAK_USER_AGENT)
+        generic_result = probe_url(url, GENERIC_USER_AGENT)
+
+        best_tak = tak_result
+        best_generic = generic_result
+        best_url = url
+
+        # If either UA got a 200, this URL is decisive — stop here.
+        if tak_result[0] == 200 or generic_result[0] == 200:
+            break
+
+    return best_tak, best_generic, best_url
+
+
+def _probe_multilayer(root: ET.Element, filepath: Path, map_name: str) -> ProbeResult:
+    """Probe every layer of a multi-layer source and report the worst status.
+
+    Each layer is probed independently and classified on its own; the source
+    inherits its least-healthy layer's status. This prevents an always-up base
+    layer (e.g. Esri World Imagery) from masking a dead data overlay — the
+    whole reason the composite source exists. The failing layer is named in
+    the error field so reports point at the layer that actually broke.
+    """
+    layers_el = root.find("layers")
+    layers = list(layers_el) if layers_el is not None else []
+
+    if not layers:
+        return ProbeResult(
+            filepath=filepath,
+            map_name=map_name,
+            status=ProbeStatus.DEAD,
+            tak_status_code=None,
+            tak_error="customMultiLayerMapSource has no <layers> to probe",
+            generic_status_code=None,
+            generic_error="customMultiLayerMapSource has no <layers> to probe",
+            test_url="",
+        )
+
+    worst_severity = -1
+    worst: ProbeResult | None = None
+
+    for i, layer in enumerate(layers, start=1):
+        layer_name = layer.findtext("name") or f"layer {i}"
+        layer_urls = build_test_urls(layer)
+
+        if not layer_urls:
+            status = ProbeStatus.DEAD
+            tak: _ProbeTuple = (None, "No test URLs could be built", False, 0)
+            generic: _ProbeTuple = (None, "No test URLs could be built", False, 0)
+            url = ""
+        else:
+            tak, generic, url = _probe_url_list(layer_urls)
+            status = classify(tak, generic)
+
+        # Strict > keeps the first-encountered layer on ties, so a healthy
+        # source reports its first layer's (clean) diagnostics.
+        if _STATUS_SEVERITY[status] > worst_severity:
+            worst_severity = _STATUS_SEVERITY[status]
+            tak_error = tak[1]
+            generic_error = generic[1]
+            if status is not ProbeStatus.HEALTHY:
+                # Point the report at the layer that actually broke.
+                tak_error = f"layer {layer_name}: {tak_error}"
+                generic_error = f"layer {layer_name}: {generic_error}"
+            worst = ProbeResult(
+                filepath=filepath,
+                map_name=map_name,
+                status=status,
+                tak_status_code=tak[0],
+                tak_error=tak_error,
+                generic_status_code=generic[0],
+                generic_error=generic_error,
+                test_url=url,
+            )
+
+    if worst is None:  # pragma: no cover - layers is non-empty, loop set it
+        raise RuntimeError("multi-layer source had layers but produced no result")
+    return worst
+
 
 def probe_source(root: ET.Element, filepath: Path) -> ProbeResult:
     """Probe a single map source with both user agents.
 
-    Tries multiple zoom-level URLs; first successful probe wins.
+    Tries multiple zoom-level URLs; first successful probe wins. Multi-layer
+    sources are probed per layer and inherit their worst layer's status.
     """
     map_name = root.findtext("name", "Unknown")
+
+    if root.tag == "customMultiLayerMapSource":
+        return _probe_multilayer(root, filepath, map_name)
+
     test_urls = build_test_urls(root)
 
     if not test_urls:
@@ -287,40 +393,7 @@ def probe_source(root: ET.Element, filepath: Path) -> ProbeResult:
             test_url="",
         )
 
-    # Try each URL; first one where at least one UA gets a 200 wins
-    best_tak: tuple[int | None, str | None, bool, int] = (
-        None,
-        "No URLs probed",
-        False,
-        0,
-    )
-    best_generic: tuple[int | None, str | None, bool, int] = (
-        None,
-        "No URLs probed",
-        False,
-        0,
-    )
-    best_url = test_urls[0]
-
-    for url in test_urls:
-        tak_result = probe_url(url, TAK_USER_AGENT)
-        generic_result = probe_url(url, GENERIC_USER_AGENT)
-
-        tak_code = tak_result[0]
-        gen_code = generic_result[0]
-
-        # If either got a 200, use this URL's results
-        if tak_code == 200 or gen_code == 200:
-            best_tak = tak_result
-            best_generic = generic_result
-            best_url = url
-            break
-
-        # Keep last results as fallback
-        best_tak = tak_result
-        best_generic = generic_result
-        best_url = url
-
+    best_tak, best_generic, best_url = _probe_url_list(test_urls)
     status = classify(best_tak, best_generic)
 
     return ProbeResult(

--- a/mapvalidator/xml_checks.py
+++ b/mapvalidator/xml_checks.py
@@ -326,14 +326,10 @@ def _check_multilayer(root: ET.Element, result: ValidationResult) -> None:
             try:
                 value = float(part)
             except ValueError:
-                result.errors.append(
-                    f"<layersAlpha> value is not a number: {part}"
-                )
+                result.errors.append(f"<layersAlpha> value is not a number: {part}")
                 continue
             if not 0.0 <= value <= 1.0:
-                result.errors.append(
-                    f"<layersAlpha> value out of range 0..1: {part}"
-                )
+                result.errors.append(f"<layersAlpha> value out of range 0..1: {part}")
 
     for i, layer in enumerate(layers, start=1):
         sub = ValidationResult(

--- a/mapvalidator/xml_checks.py
+++ b/mapvalidator/xml_checks.py
@@ -304,8 +304,18 @@ def _check_multilayer(root: ET.Element, result: ValidationResult) -> None:
         result.errors.append("customMultiLayerMapSource has no <layers>")
         return
 
+    # backgroundColor is valid on the multi-layer root (xs:string in the XSD,
+    # so the schema can't catch the ATAK single-hex-digit parser bug); the
+    # per-layer dispatch below never sees the root, so check it here.
+    _check_background_color(root, result)
+
     alpha_text = root.findtext("layersAlpha")
-    if alpha_text is not None:
+    if alpha_text is None:
+        result.info.append(
+            "<layersAlpha> not specified — ATAK applies its default "
+            "per-layer opacity"
+        )
+    else:
         parts = alpha_text.split()
         if len(parts) != len(layers):
             result.errors.append(
@@ -331,10 +341,16 @@ def _check_multilayer(root: ET.Element, result: ValidationResult) -> None:
             map_name=layer.findtext("name") or f"layer {i}",
             source_type=_source_type_from_tag(layer.tag),
         )
-        _check_single_source(layer, sub)
+        # The XSD allows a customMultiLayerMapSource to nest another one, so
+        # dispatch by tag rather than assuming every layer is a plain source.
+        if layer.tag == "customMultiLayerMapSource":
+            _check_multilayer(layer, sub)
+        else:
+            _check_single_source(layer, sub)
         label = layer.findtext("name") or f"#{i}"
         result.errors.extend(f"layer {label}: {msg}" for msg in sub.errors)
         result.warnings.extend(f"layer {label}: {msg}" for msg in sub.warnings)
+        result.info.extend(f"layer {label}: {msg}" for msg in sub.info)
 
 
 def validate_file(filepath: Path) -> ValidationResult:

--- a/mapvalidator/xml_checks.py
+++ b/mapvalidator/xml_checks.py
@@ -272,6 +272,71 @@ def _check_background_color(root: ET.Element, result: ValidationResult) -> None:
         )
 
 
+def _check_single_source(root: ET.Element, result: ValidationResult) -> None:
+    """Run the per-source checks shared by plain and nested map sources."""
+    _check_zoom_levels(root, result)
+    _check_tile_type(root, result)
+
+    if root.tag == "customMapSource":
+        _check_tms_url(root, result)
+    elif root.tag == "customWmsMapSource":
+        _check_wms_source(root, result)
+
+    _check_serverparts(root, result)
+    _check_coordinate_system(root, result)
+    _check_http_url(root, result)
+    _check_invert_y(root, result)
+    _check_tile_update(root, result)
+    _check_background_color(root, result)
+
+
+def _check_multilayer(root: ET.Element, result: ValidationResult) -> None:
+    """Validate a customMultiLayerMapSource.
+
+    The root carries only name/layers/layersAlpha/backgroundColor (see
+    schema/mobac-maps.xsd); zoom, url, and tileType live on each nested
+    layer, so the per-source checks run per layer with messages prefixed
+    by the layer name.
+    """
+    layers_el = root.find("layers")
+    layers = list(layers_el) if layers_el is not None else []
+    if not layers:
+        result.errors.append("customMultiLayerMapSource has no <layers>")
+        return
+
+    alpha_text = root.findtext("layersAlpha")
+    if alpha_text is not None:
+        parts = alpha_text.split()
+        if len(parts) != len(layers):
+            result.errors.append(
+                f"<layersAlpha> has {len(parts)} values for {len(layers)} "
+                "layers — ATAK rejects the source when the counts differ"
+            )
+        for part in parts:
+            try:
+                value = float(part)
+            except ValueError:
+                result.errors.append(
+                    f"<layersAlpha> value is not a number: {part}"
+                )
+                continue
+            if not 0.0 <= value <= 1.0:
+                result.errors.append(
+                    f"<layersAlpha> value out of range 0..1: {part}"
+                )
+
+    for i, layer in enumerate(layers, start=1):
+        sub = ValidationResult(
+            filepath=result.filepath,
+            map_name=layer.findtext("name") or f"layer {i}",
+            source_type=_source_type_from_tag(layer.tag),
+        )
+        _check_single_source(layer, sub)
+        label = layer.findtext("name") or f"#{i}"
+        result.errors.extend(f"layer {label}: {msg}" for msg in sub.errors)
+        result.warnings.extend(f"layer {label}: {msg}" for msg in sub.warnings)
+
+
 def validate_file(filepath: Path) -> ValidationResult:
     """Run all checks on a single XML map file and return a ValidationResult."""
     result = ValidationResult(
@@ -294,25 +359,12 @@ def validate_file(filepath: Path) -> ValidationResult:
     result.map_name = root.findtext("name") or "Unknown"
     result.source_type = _source_type_from_tag(root.tag)
 
-    # Zoom level checks
-    _check_zoom_levels(root, result)
-
-    # Tile type checks
-    _check_tile_type(root, result)
-
-    # Type-specific checks
-    if root.tag == "customMapSource":
-        _check_tms_url(root, result)
-    elif root.tag == "customWmsMapSource":
-        _check_wms_source(root, result)
-
-    # Common checks
-    _check_serverparts(root, result)
-    _check_coordinate_system(root, result)
-    _check_http_url(root, result)
-    _check_invert_y(root, result)
-    _check_tile_update(root, result)
-    _check_background_color(root, result)
+    # Per-source checks: multi-layer sources carry zoom/url/tileType on their
+    # nested layers rather than the root, so dispatch accordingly
+    if root.tag == "customMultiLayerMapSource":
+        _check_multilayer(root, result)
+    else:
+        _check_single_source(root, result)
     _check_additional_parameters(root, result)
     _check_version_whitespace(root, result)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -389,3 +389,74 @@ EMPTY_SERVERPARTS_NO_PLACEHOLDER_XML = """\
     <serverParts></serverParts>
 </customMapSource>
 """
+
+VALID_MULTILAYER_XML = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<customMultiLayerMapSource>
+    <name>Test Multi-Layer Map</name>
+    <layersAlpha>1.0 0.5</layersAlpha>
+    <layers>
+        <customMapSource>
+            <name>Base</name>
+            <minZoom>1</minZoom>
+            <maxZoom>18</maxZoom>
+            <tileType>jpg</tileType>
+            <url>https://tiles.example.com/base/{$z}/{$y}/{$x}</url>
+        </customMapSource>
+        <customMapSource>
+            <name>Overlay</name>
+            <minZoom>1</minZoom>
+            <maxZoom>14</maxZoom>
+            <tileType>png</tileType>
+            <url>https://tiles.example.com/overlay/{$z}/{$y}/{$x}</url>
+        </customMapSource>
+    </layers>
+</customMultiLayerMapSource>
+"""
+
+MULTILAYER_LAYER_MISSING_MAXZOOM_XML = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<customMultiLayerMapSource>
+    <name>Multi-Layer Missing MaxZoom</name>
+    <layers>
+        <customMapSource>
+            <name>Base</name>
+            <minZoom>1</minZoom>
+            <tileType>jpg</tileType>
+            <url>https://tiles.example.com/base/{$z}/{$y}/{$x}</url>
+        </customMapSource>
+    </layers>
+</customMultiLayerMapSource>
+"""
+
+MULTILAYER_ALPHA_COUNT_MISMATCH_XML = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<customMultiLayerMapSource>
+    <name>Multi-Layer Alpha Mismatch</name>
+    <layersAlpha>1.0</layersAlpha>
+    <layers>
+        <customMapSource>
+            <name>Base</name>
+            <minZoom>1</minZoom>
+            <maxZoom>18</maxZoom>
+            <tileType>jpg</tileType>
+            <url>https://tiles.example.com/base/{$z}/{$y}/{$x}</url>
+        </customMapSource>
+        <customMapSource>
+            <name>Overlay</name>
+            <minZoom>1</minZoom>
+            <maxZoom>14</maxZoom>
+            <tileType>png</tileType>
+            <url>https://tiles.example.com/overlay/{$z}/{$y}/{$x}</url>
+        </customMapSource>
+    </layers>
+</customMultiLayerMapSource>
+"""
+
+MULTILAYER_NO_LAYERS_XML = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<customMultiLayerMapSource>
+    <name>Multi-Layer Empty</name>
+    <layers></layers>
+</customMultiLayerMapSource>
+"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -460,3 +460,134 @@ MULTILAYER_NO_LAYERS_XML = """\
     <layers></layers>
 </customMultiLayerMapSource>
 """
+
+# Valid layers but no <layersAlpha> — should be informational, not an error.
+MULTILAYER_NO_ALPHA_XML = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<customMultiLayerMapSource>
+    <name>Multi-Layer No Alpha</name>
+    <layers>
+        <customMapSource>
+            <name>Base</name>
+            <minZoom>1</minZoom>
+            <maxZoom>18</maxZoom>
+            <tileType>jpg</tileType>
+            <url>https://tiles.example.com/base/{$z}/{$y}/{$x}</url>
+        </customMapSource>
+        <customMapSource>
+            <name>Overlay</name>
+            <minZoom>1</minZoom>
+            <maxZoom>14</maxZoom>
+            <tileType>png</tileType>
+            <url>https://tiles.example.com/overlay/{$z}/{$y}/{$x}</url>
+        </customMapSource>
+    </layers>
+</customMultiLayerMapSource>
+"""
+
+# backgroundColor on the multi-layer root with >1 hex digit after '#' — trips
+# the ATAK single-hex-digit parser-bug check, which lives in .info.
+MULTILAYER_ROOT_BACKGROUND_XML = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<customMultiLayerMapSource>
+    <name>Multi-Layer Root Background</name>
+    <backgroundColor>#000000</backgroundColor>
+    <layersAlpha>1.0 0.5</layersAlpha>
+    <layers>
+        <customMapSource>
+            <name>Base</name>
+            <minZoom>1</minZoom>
+            <maxZoom>18</maxZoom>
+            <tileType>jpg</tileType>
+            <url>https://tiles.example.com/base/{$z}/{$y}/{$x}</url>
+        </customMapSource>
+        <customMapSource>
+            <name>Overlay</name>
+            <minZoom>1</minZoom>
+            <maxZoom>14</maxZoom>
+            <tileType>png</tileType>
+            <url>https://tiles.example.com/overlay/{$z}/{$y}/{$x}</url>
+        </customMapSource>
+    </layers>
+</customMultiLayerMapSource>
+"""
+
+MULTILAYER_ALPHA_OUT_OF_RANGE_XML = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<customMultiLayerMapSource>
+    <name>Multi-Layer Alpha Out Of Range</name>
+    <layersAlpha>1.5 0.5</layersAlpha>
+    <layers>
+        <customMapSource>
+            <name>Base</name>
+            <minZoom>1</minZoom>
+            <maxZoom>18</maxZoom>
+            <tileType>jpg</tileType>
+            <url>https://tiles.example.com/base/{$z}/{$y}/{$x}</url>
+        </customMapSource>
+        <customMapSource>
+            <name>Overlay</name>
+            <minZoom>1</minZoom>
+            <maxZoom>14</maxZoom>
+            <tileType>png</tileType>
+            <url>https://tiles.example.com/overlay/{$z}/{$y}/{$x}</url>
+        </customMapSource>
+    </layers>
+</customMultiLayerMapSource>
+"""
+
+# A layer that is itself a customMultiLayerMapSource (the XSD permits nesting).
+# The inner source has a layer missing <maxZoom>, which must surface through
+# two levels of layer-name prefixing.
+MULTILAYER_NESTED_XML = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<customMultiLayerMapSource>
+    <name>Outer</name>
+    <layersAlpha>1.0 0.5</layersAlpha>
+    <layers>
+        <customMapSource>
+            <name>Plain Base</name>
+            <minZoom>1</minZoom>
+            <maxZoom>18</maxZoom>
+            <tileType>jpg</tileType>
+            <url>https://tiles.example.com/base/{$z}/{$y}/{$x}</url>
+        </customMapSource>
+        <customMultiLayerMapSource>
+            <name>Inner</name>
+            <layersAlpha>1.0</layersAlpha>
+            <layers>
+                <customMapSource>
+                    <name>InnerBad</name>
+                    <minZoom>1</minZoom>
+                    <tileType>png</tileType>
+                    <url>https://tiles.example.com/inner/{$z}/{$y}/{$x}</url>
+                </customMapSource>
+            </layers>
+        </customMultiLayerMapSource>
+    </layers>
+</customMultiLayerMapSource>
+"""
+
+MULTILAYER_ALPHA_NON_NUMERIC_XML = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<customMultiLayerMapSource>
+    <name>Multi-Layer Alpha Non Numeric</name>
+    <layersAlpha>opaque 0.5</layersAlpha>
+    <layers>
+        <customMapSource>
+            <name>Base</name>
+            <minZoom>1</minZoom>
+            <maxZoom>18</maxZoom>
+            <tileType>jpg</tileType>
+            <url>https://tiles.example.com/base/{$z}/{$y}/{$x}</url>
+        </customMapSource>
+        <customMapSource>
+            <name>Overlay</name>
+            <minZoom>1</minZoom>
+            <maxZoom>14</maxZoom>
+            <tileType>png</tileType>
+            <url>https://tiles.example.com/overlay/{$z}/{$y}/{$x}</url>
+        </customMapSource>
+    </layers>
+</customMultiLayerMapSource>
+"""

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -740,3 +740,15 @@ class TestProbeAllSmokeFlag:
         results = probe_all(tmp_path, smoke_only=True)
         assert len(results) == 1
         assert results[0].filepath.name == "google_hybrid.xml"
+
+
+class TestBuildTestUrlsMultiLayer:
+    def test_multilayer_collects_urls_from_nested_layers(self):
+        """Multi-layer sources have no root <url>; URLs come from each layer."""
+        from tests.conftest import VALID_MULTILAYER_XML
+
+        root = ET.fromstring(VALID_MULTILAYER_XML)
+        urls = build_test_urls(root)
+        assert urls, "expected test URLs built from nested layers"
+        assert any("tiles.example.com/base" in u for u in urls)
+        assert any("tiles.example.com/overlay" in u for u in urls)

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -1,9 +1,8 @@
 """Tests for mapvalidator.probe module."""
 
+import re
 import xml.etree.ElementTree as ET
 from pathlib import Path
-
-import re
 
 import responses
 from requests.exceptions import ConnectionError, Timeout
@@ -752,3 +751,118 @@ class TestBuildTestUrlsMultiLayer:
         assert urls, "expected test URLs built from nested layers"
         assert any("tiles.example.com/base" in u for u in urls)
         assert any("tiles.example.com/overlay" in u for u in urls)
+
+
+# ---------------------------------------------------------------------------
+# 22. probe_source — multi-layer aggregates to the worst layer's status
+# ---------------------------------------------------------------------------
+
+
+MULTILAYER_PROBE_XML = """
+<customMultiLayerMapSource>
+    <name>Base Plus Overlay</name>
+    <layersAlpha>1.0 0.5</layersAlpha>
+    <layers>
+        <customMapSource>
+            <name>Live Base</name>
+            <minZoom>1</minZoom>
+            <maxZoom>14</maxZoom>
+            <tileType>jpg</tileType>
+            <url>https://base.example.com/{$z}/{$x}/{$y}</url>
+        </customMapSource>
+        <customMapSource>
+            <name>Overlay Data</name>
+            <minZoom>1</minZoom>
+            <maxZoom>14</maxZoom>
+            <tileType>png</tileType>
+            <url>https://overlay.example.com/{$z}/{$x}/{$y}</url>
+        </customMapSource>
+    </layers>
+</customMultiLayerMapSource>
+"""
+
+
+class TestProbeSourceMultiLayerAggregatesWorst:
+    @responses.activate
+    def test_live_base_dead_overlay_reports_dead(self):
+        # An always-up base must not mask a dead overlay: the source is only
+        # as healthy as its worst layer, and the failing layer is named.
+        responses.add(
+            responses.GET,
+            re.compile(r"https://base\.example\.com/.*"),
+            body=b"\xff\xd8\xff",
+            status=200,
+            content_type="image/jpeg",
+        )
+        responses.add(
+            responses.GET,
+            re.compile(r"https://overlay\.example\.com/.*"),
+            status=500,
+            body=b"Error",
+        )
+
+        root = _xml(MULTILAYER_PROBE_XML)
+        result = probe_source(root, Path("BLM/test.xml"))
+
+        assert result.status == ProbeStatus.DEAD
+        assert "Overlay Data" in (result.tak_error or "")
+
+    @responses.activate
+    def test_all_layers_healthy_reports_healthy(self):
+        responses.add(
+            responses.GET,
+            re.compile(r"https://base\.example\.com/.*"),
+            body=b"\xff\xd8\xff",
+            status=200,
+            content_type="image/jpeg",
+        )
+        responses.add(
+            responses.GET,
+            re.compile(r"https://overlay\.example\.com/.*"),
+            body=b"\x89PNG\r\n",
+            status=200,
+            content_type="image/png",
+        )
+
+        root = _xml(MULTILAYER_PROBE_XML)
+        result = probe_source(root, Path("BLM/test.xml"))
+
+        assert result.status == ProbeStatus.HEALTHY
+
+    @responses.activate
+    def test_layer_with_no_url_is_dead_and_named(self):
+        # A layer whose URL can't be built yields no probe targets: it counts
+        # as DEAD and drags the composite down, even with a healthy sibling.
+        responses.add(
+            responses.GET,
+            re.compile(r"https://base\.example\.com/.*"),
+            body=b"\xff\xd8\xff",
+            status=200,
+            content_type="image/jpeg",
+        )
+        xml = """
+        <customMultiLayerMapSource>
+            <name>Base Plus Urlless</name>
+            <layersAlpha>1.0 0.5</layersAlpha>
+            <layers>
+                <customMapSource>
+                    <name>Live Base</name>
+                    <minZoom>1</minZoom>
+                    <maxZoom>14</maxZoom>
+                    <tileType>jpg</tileType>
+                    <url>https://base.example.com/{$z}/{$x}/{$y}</url>
+                </customMapSource>
+                <customMapSource>
+                    <name>No URL</name>
+                    <minZoom>1</minZoom>
+                    <maxZoom>14</maxZoom>
+                    <tileType>png</tileType>
+                </customMapSource>
+            </layers>
+        </customMultiLayerMapSource>
+        """
+        result = probe_source(_xml(xml), Path("BLM/test.xml"))
+
+        assert result.status == ProbeStatus.DEAD
+        assert "No URL" in (result.tak_error or "")
+        assert "No test URLs" in (result.tak_error or "")

--- a/tests/test_xml_checks.py
+++ b/tests/test_xml_checks.py
@@ -32,10 +32,14 @@ from tests.conftest import (
     QUADKEY_TMS_XML,
     SERVERPART_URL_NO_ELEMENT_XML,
     SERVERPARTS_ELEMENT_NO_URL_XML,
+    MULTILAYER_ALPHA_COUNT_MISMATCH_XML,
+    MULTILAYER_LAYER_MISSING_MAXZOOM_XML,
+    MULTILAYER_NO_LAYERS_XML,
     TILE_UPDATE_IFNONEMATCH_XML,
     TILE_UPDATE_NONE_XML,
     TILE_UPDATE_NUMERIC_XML,
     UNKNOWN_TILETYPE_XML,
+    VALID_MULTILAYER_XML,
     VALID_TMS_XML,
     VALID_WMS_XML,
     VERSION_WHITESPACE_XML,
@@ -608,3 +612,37 @@ class TestEmptyServerParts:
         result = validate_file(tmp_xml(EMPTY_SERVERPARTS_NO_PLACEHOLDER_XML))
         assert not _has_message(result.errors, "serverParts")
         assert not _has_message(result.errors, "serverpart")
+
+
+# ============================================================
+# 19. Multi-layer sources — per-layer checks, layersAlpha sanity
+# ============================================================
+
+
+class TestMultiLayer:
+    def test_valid_multilayer_no_errors(self, tmp_xml):
+        """A well-formed customMultiLayerMapSource passes with no errors."""
+        result = validate_file(tmp_xml(VALID_MULTILAYER_XML))
+        assert result.errors == []
+        assert result.source_type == "Multi-Layer"
+
+    def test_multilayer_maxzoom_checked_per_layer_not_root(self, tmp_xml):
+        """Root carries no maxZoom (per the XSD); a valid file must not error."""
+        result = validate_file(tmp_xml(VALID_MULTILAYER_XML))
+        assert not _has_message(result.errors, "maxZoom")
+
+    def test_multilayer_layer_missing_maxzoom_errors(self, tmp_xml):
+        """A nested layer without <maxZoom> is reported, prefixed by layer name."""
+        result = validate_file(tmp_xml(MULTILAYER_LAYER_MISSING_MAXZOOM_XML))
+        assert _has_message(result.errors, "maxZoom")
+        assert _has_message(result.errors, "layer Base")
+
+    def test_multilayer_alpha_count_mismatch_errors(self, tmp_xml):
+        """layersAlpha value count must equal the layer count."""
+        result = validate_file(tmp_xml(MULTILAYER_ALPHA_COUNT_MISMATCH_XML))
+        assert _has_message(result.errors, "layersAlpha")
+
+    def test_multilayer_no_layers_errors(self, tmp_xml):
+        """An empty <layers> container is an error."""
+        result = validate_file(tmp_xml(MULTILAYER_NO_LAYERS_XML))
+        assert _has_message(result.errors, "no <layers>")

--- a/tests/test_xml_checks.py
+++ b/tests/test_xml_checks.py
@@ -28,10 +28,6 @@ from tests.conftest import (
     MAX_ZOOM_26_XML,
     MISSING_TILETYPE_TMS_XML,
     MISSING_URL_PLACEHOLDERS_XML,
-    NEGATIVE_MINZOOM_XML,
-    QUADKEY_TMS_XML,
-    SERVERPART_URL_NO_ELEMENT_XML,
-    SERVERPARTS_ELEMENT_NO_URL_XML,
     MULTILAYER_ALPHA_COUNT_MISMATCH_XML,
     MULTILAYER_ALPHA_NON_NUMERIC_XML,
     MULTILAYER_ALPHA_OUT_OF_RANGE_XML,
@@ -40,6 +36,10 @@ from tests.conftest import (
     MULTILAYER_NO_ALPHA_XML,
     MULTILAYER_NO_LAYERS_XML,
     MULTILAYER_ROOT_BACKGROUND_XML,
+    NEGATIVE_MINZOOM_XML,
+    QUADKEY_TMS_XML,
+    SERVERPART_URL_NO_ELEMENT_XML,
+    SERVERPARTS_ELEMENT_NO_URL_XML,
     TILE_UPDATE_IFNONEMATCH_XML,
     TILE_UPDATE_NONE_XML,
     TILE_UPDATE_NUMERIC_XML,
@@ -683,6 +683,5 @@ class TestMultiLayer:
         result = validate_file(tmp_xml(MULTILAYER_NESTED_XML))
         assert _has_message(result.errors, "maxZoom")
         assert any(
-            "layer Inner" in msg and "layer InnerBad" in msg
-            for msg in result.errors
+            "layer Inner" in msg and "layer InnerBad" in msg for msg in result.errors
         )

--- a/tests/test_xml_checks.py
+++ b/tests/test_xml_checks.py
@@ -33,8 +33,13 @@ from tests.conftest import (
     SERVERPART_URL_NO_ELEMENT_XML,
     SERVERPARTS_ELEMENT_NO_URL_XML,
     MULTILAYER_ALPHA_COUNT_MISMATCH_XML,
+    MULTILAYER_ALPHA_NON_NUMERIC_XML,
+    MULTILAYER_ALPHA_OUT_OF_RANGE_XML,
     MULTILAYER_LAYER_MISSING_MAXZOOM_XML,
+    MULTILAYER_NESTED_XML,
+    MULTILAYER_NO_ALPHA_XML,
     MULTILAYER_NO_LAYERS_XML,
+    MULTILAYER_ROOT_BACKGROUND_XML,
     TILE_UPDATE_IFNONEMATCH_XML,
     TILE_UPDATE_NONE_XML,
     TILE_UPDATE_NUMERIC_XML,
@@ -646,3 +651,38 @@ class TestMultiLayer:
         """An empty <layers> container is an error."""
         result = validate_file(tmp_xml(MULTILAYER_NO_LAYERS_XML))
         assert _has_message(result.errors, "no <layers>")
+
+    def test_multilayer_absent_alpha_is_info_not_error(self, tmp_xml):
+        """A missing <layersAlpha> is informational, not a validation error."""
+        result = validate_file(tmp_xml(MULTILAYER_NO_ALPHA_XML))
+        assert not _has_message(result.errors, "layersAlpha")
+        assert _has_message(result.info, "layersAlpha")
+
+    def test_multilayer_root_background_color_checked(self, tmp_xml):
+        """backgroundColor on the multi-layer root is run through the check."""
+        result = validate_file(tmp_xml(MULTILAYER_ROOT_BACKGROUND_XML))
+        # Not prefixed with "layer ..." — it belongs to the root, not a layer.
+        assert any(
+            "backgroundColor" in msg and not msg.startswith("layer ")
+            for msg in result.info
+        )
+
+    def test_multilayer_alpha_out_of_range_errors(self, tmp_xml):
+        """layersAlpha values must fall within 0..1."""
+        result = validate_file(tmp_xml(MULTILAYER_ALPHA_OUT_OF_RANGE_XML))
+        assert _has_message(result.errors, "out of range")
+
+    def test_multilayer_alpha_non_numeric_errors(self, tmp_xml):
+        """Non-numeric layersAlpha values are reported."""
+        result = validate_file(tmp_xml(MULTILAYER_ALPHA_NON_NUMERIC_XML))
+        assert _has_message(result.errors, "not a number")
+
+    def test_nested_multilayer_errors_surface_with_double_prefix(self, tmp_xml):
+        """A layer that is itself a multi-layer source is validated recursively,
+        and inner errors surface through two levels of layer-name prefixing."""
+        result = validate_file(tmp_xml(MULTILAYER_NESTED_XML))
+        assert _has_message(result.errors, "maxZoom")
+        assert any(
+            "layer Inner" in msg and "layer InnerBad" in msg
+            for msg in result.errors
+        )


### PR DESCRIPTION
## What

Adds the BLM Surface Management Agency land-ownership layer, the dataset services like onX and Gaia build their public-lands view from. Came out of a r/ATAK request for BLM boundary overlays for the desert states.

Three files:

- `BLM/blm_land_ownership_sma.xml`: full ownership basemap (yellow BLM, green USFS, lavender NPS, orange BIA, light blue state, white private)
- `BLM/blm_satellite_land_ownership.xml`: Esri World Imagery with the ownership colors composited at 50% opacity via layersAlpha. First customMultiLayerMapSource in the collection.
- `GRG/grg_blm_public_lands_overlay.xml`: the SMA variant that leaves private land transparent, so it works as an overlay above any basemap

Data is BLM public domain (copyrightText: BLM Energy, Minerals and Realty Management). The cache is standard 256px Web Mercator and ends at zoom 14 (~10 m/px); the service advertises exportTilesAllowed with a 100k per-request ceiling, so ATAK bulk region downloads are sanctioned use.

## Validator fix that rode along

Since this adds the first multi-layer source, it also exercised a dormant path in mapvalidator: zoom/url/tileType checks ran against the root only, so any customMultiLayerMapSource failed validation (missing maxZoom, which the XSD correctly forbids at the root) and probed as dead (no test URLs built). First commit fixes both: per-source checks now run per nested layer with layer-prefixed messages, layersAlpha gets count and range checks, and the prober collects URLs from every layer. Five new validator tests plus one probe test.

## Verification

- `validate.sh --strict`: 0 errors (the 28 pre-existing warnings on older files are untouched)
- pytest: 133 passed, coverage 92.8%
- Probe: all three sources HEALTHY (200 under both user agents)
- Rendered all three in ATAK-CIV 5.7.0.9 on an emulator: ownership colors, the satellite blend, and the transparent-private overlay all draw correctly over Moab, UT (mixed BLM, NPS, state trust and private parcels)