### PR TITLE
fix(bc-wildfire): conform merged source to schema and conventions

### DIFF
--- a/GRG/grg_bc_wildfire_perimeters_current.xml
+++ b/GRG/grg_bc_wildfire_perimeters_current.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <customWmsMapSource>
-    <name>BC Wildfire Fire Perimeters - Current on DataBC Public Web Map Service</name>
+    <name>BC Wildfire - Fire Perimeters (Current)</name>
     <version>1.3.0</version>
     <minZoom>0</minZoom>
-    <maxZoom>23</maxZoom>
+    <maxZoom>22</maxZoom>
     <tileType>png</tileType>
     <url>https://openmaps.gov.bc.ca/geo/pub/WHSE_LAND_AND_NATURAL_RESOURCE.PROT_CURRENT_FIRE_POLYS_SP/ows?SERVICE=WMS&amp;</url>
     <coordinatesystem>EPSG:3857</coordinatesystem>
     <layers>pub:WHSE_LAND_AND_NATURAL_RESOURCE.PROT_CURRENT_FIRE_POLYS_SP</layers>
     <styles>1751_1752</styles>
     <north>8534215.479697939</north>
-    <east>-1.229275523998929E7</east>
+    <east>-12292755.23998929</east>
     <south>6045873.0184186315</south>
-    <west>-1.5479220221745186E7</west>
+    <west>-15479220.221745186</west>
     <backgroundColor>#000000</backgroundColor>
     <aditionalparameters>&amp;transparent=true</aditionalparameters>
 </customWmsMapSource>


### PR DESCRIPTION
Follow-up to #76. The PR merged before the maintainer cleanup commits reached the fork branch (a force-push race), so the unmodified source landed on master and **fails XSD validation** (`east`/`west` bbox coords are in scientific notation, which `xs:decimal` rejects).

This corrects the merged file:
- Rename `BC-Wildfire-Fire-Perimeters-Current.xml` → `grg_bc_wildfire_perimeters_current.xml` (grg_ overlay convention), drop the exec bit.
- Scientific-notation bbox coords → plain decimals (fixes schema validation).
- `maxZoom` 23 → 22 (ATAK-supported max). Tidy display name.

Verified: XSD validates, mapvalidator 0 errors/0 warnings, live-probes HEALTHY against the DataBC WMS. Credit to @RoadDogsAndTruckerHats for the original source.