### PR TITLE
feat: add Ordnance Survey map layers (Great Britain)

### DIFF
--- a/OrdnanceSurvey/os_light_3857.xml
+++ b/OrdnanceSurvey/os_light_3857.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<customMapSource>
+    <name>OS - Light 3857</name>
+    <minZoom>0</minZoom>
+    <maxZoom>16</maxZoom>
+    <tileType>png</tileType>
+    <!--
+        Ordnance Survey OS Maps API (Great Britain only). Requires a free API
+        key: sign up at https://osdatahub.os.uk, create an "OS Maps API"
+        project, and replace API_KEY_HERE below with your key. The free tier
+        covers generous monthly tile usage. Web Mercator (EPSG:3857) cache;
+        the Light style tops out at zoom 16.
+    -->
+    <url>https://api.os.uk/maps/raster/v1/zxy/Light_3857/{$z}/{$x}/{$y}.png?key=API_KEY_HERE</url>
+    <backgroundColor>#000000</backgroundColor>
+</customMapSource>

--- a/OrdnanceSurvey/os_outdoor_3857.xml
+++ b/OrdnanceSurvey/os_outdoor_3857.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<customMapSource>
+    <name>OS - Outdoor 3857</name>
+    <minZoom>0</minZoom>
+    <maxZoom>16</maxZoom>
+    <tileType>png</tileType>
+    <!--
+        Ordnance Survey OS Maps API (Great Britain only). Requires a free API
+        key: sign up at https://osdatahub.os.uk, create an "OS Maps API"
+        project, and replace API_KEY_HERE below with your key. The free tier
+        covers generous monthly tile usage. Web Mercator (EPSG:3857) cache;
+        the Outdoor style tops out at zoom 16.
+    -->
+    <url>https://api.os.uk/maps/raster/v1/zxy/Outdoor_3857/{$z}/{$x}/{$y}.png?key=API_KEY_HERE</url>
+    <backgroundColor>#000000</backgroundColor>
+</customMapSource>

--- a/OrdnanceSurvey/os_road_3857.xml
+++ b/OrdnanceSurvey/os_road_3857.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<customMapSource>
+    <name>OS - Road 3857</name>
+    <minZoom>0</minZoom>
+    <maxZoom>16</maxZoom>
+    <tileType>png</tileType>
+    <!--
+        Ordnance Survey OS Maps API (Great Britain only). Requires a free API
+        key: sign up at https://osdatahub.os.uk, create an "OS Maps API"
+        project, and replace API_KEY_HERE below with your key. The free tier
+        covers generous monthly tile usage. Web Mercator (EPSG:3857) cache;
+        the Road style tops out at zoom 16.
+    -->
+    <url>https://api.os.uk/maps/raster/v1/zxy/Road_3857/{$z}/{$x}/{$y}.png?key=API_KEY_HERE</url>
+    <backgroundColor>#000000</backgroundColor>
+</customMapSource>

--- a/mapvalidator/probe.py
+++ b/mapvalidator/probe.py
@@ -54,6 +54,7 @@ class ProbeStatus(Enum):
     BLOCKED = "blocked"
     DEAD = "dead"
     DEGRADED = "degraded"
+    SKIPPED = "skipped"  # not probed (e.g. URL needs an API key not yet filled)
 
 
 @dataclass
@@ -368,18 +369,46 @@ def _probe_multilayer(root: ET.Element, filepath: Path, map_name: str) -> ProbeR
     return worst
 
 
+# Placeholder tokens contributors leave in a URL where the user must paste
+# their own API key. Such a source can't be liveness-probed until configured,
+# so it's SKIPPED rather than reported DEAD (which would file a health issue).
+_KEY_PLACEHOLDERS = ("API_KEY_HERE", "YOUR_API_KEY", "YOUR_KEY_HERE", "{key}")
+
+
+def _needs_api_key(urls: list[str]) -> bool:
+    """True if any test URL still contains an unfilled API-key placeholder."""
+    return any(
+        placeholder.lower() in url.lower()
+        for url in urls
+        for placeholder in _KEY_PLACEHOLDERS
+    )
+
+
 def probe_source(root: ET.Element, filepath: Path) -> ProbeResult:
     """Probe a single map source with both user agents.
 
     Tries multiple zoom-level URLs; first successful probe wins. Multi-layer
     sources are probed per layer and inherit their worst layer's status.
+    Sources whose URL still carries an unfilled API-key placeholder are
+    SKIPPED (they can't be probed without the user's key).
     """
     map_name = root.findtext("name", "Unknown")
 
+    test_urls = build_test_urls(root)
+    if _needs_api_key(test_urls):
+        return ProbeResult(
+            filepath=filepath,
+            map_name=map_name,
+            status=ProbeStatus.SKIPPED,
+            tak_status_code=None,
+            tak_error="URL needs an API key (placeholder not filled); not probed",
+            generic_status_code=None,
+            generic_error="URL needs an API key (placeholder not filled); not probed",
+            test_url=test_urls[0] if test_urls else "",
+        )
+
     if root.tag == "customMultiLayerMapSource":
         return _probe_multilayer(root, filepath, map_name)
-
-    test_urls = build_test_urls(root)
 
     if not test_urls:
         return ProbeResult(

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -866,3 +866,37 @@ class TestProbeSourceMultiLayerAggregatesWorst:
         assert result.status == ProbeStatus.DEAD
         assert "No URL" in (result.tak_error or "")
         assert "No test URLs" in (result.tak_error or "")
+
+
+# ---------------------------------------------------------------------------
+# 23. probe_source — sources needing an unfilled API key are skipped, not dead
+# ---------------------------------------------------------------------------
+
+
+OS_KEY_PLACEHOLDER_XML = """
+<customMapSource>
+    <name>OS - Road 3857</name>
+    <minZoom>0</minZoom>
+    <maxZoom>16</maxZoom>
+    <tileType>png</tileType>
+    <url>https://api.example.com/{$z}/{$x}/{$y}.png?key=API_KEY_HERE</url>
+</customMapSource>
+"""
+
+
+class TestProbeSkipsUnconfiguredKeySources:
+    @responses.activate
+    def test_key_placeholder_source_is_skipped_without_http(self):
+        # No responses are registered: if probe_source made any HTTP call,
+        # the responses library would raise ConnectionError. A key-gated
+        # source must short-circuit to SKIPPED before probing.
+        root = _xml(OS_KEY_PLACEHOLDER_XML)
+        result = probe_source(root, Path("OrdnanceSurvey/os_road_3857.xml"))
+        assert result.status == ProbeStatus.SKIPPED
+        assert "key" in (result.tak_error or "").lower()
+
+    def test_skipped_status_is_not_unhealthy(self):
+        """A SKIPPED source must never trigger a map-health issue."""
+        from mapvalidator.reporter import _UNHEALTHY
+
+        assert ProbeStatus.SKIPPED not in _UNHEALTHY


### PR DESCRIPTION
Salvages the Ordnance Survey layers from #68, which had drifted **136 commits behind master** and touched 64 files (re-adding renamed files, reverting workflows, rewriting LICENSE/README). This lands just the three intended OS sources, cleanly, on current master. Credit to @nodrog1061 (co-authored).

## What

Adds the OS Maps API raster styles — **Road**, **Light**, **Outdoor** (EPSG:3857, min 0 / max 16 zoom), under `OrdnanceSurvey/`.

- Great-Britain-only coverage.
- Requires a **free** OS Maps API key (sign up at https://osdatahub.os.uk). Each file documents the steps in a comment and carries an `API_KEY_HERE` placeholder in the URL for the user to replace. No key is committed.

## Liveness-probe handling (rode along)

These are the repo's first key-gated sources. Without a key they return HTTP 401, which the weekly `map-health-check` (`--probe --issues`) would classify as DEAD and file a recurring false 'dead source' issue for. So the prober now returns a new **`SKIPPED`** status for any source whose URL still holds an unfilled key placeholder — SKIPPED is not in the unhealthy set, so no issue is filed. Covered by tests (RED-witnessed, mutation-checked).

## Verification

- XSD: all three validate.
- `mapvalidator`: 0 errors, 0 warnings.
- URL path confirmed correct: returns **401** (auth required), not 404, without a key.
- Full suite: 143 passed. All three sources probe **SKIPPED** (would_file_issue=False).