### PR TITLE
fix: per-map ATAK import fails silently (text/plain content-type)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ __pycache__/
 /site/
 /docs/qr/
 /docs/maps.md
+/docs/sources/
 .cache/

--- a/mapvalidator/catalog.py
+++ b/mapvalidator/catalog.py
@@ -9,6 +9,16 @@ from mapvalidator.qr import build_import_uri
 
 RAW_BASE = "https://raw.githubusercontent.com/joshuafuller/ATAK-Maps/master"
 
+# The tak:// import target must be served with an XML content type. raw
+# githubusercontent serves .xml as text/plain, which makes ATAK's
+# ImportFileDownloader append a ".txt" extension (Content-Type -> extension),
+# so no map-source resolver claims the file and the import silently no-ops.
+# GitHub Pages serves .xml as application/xml, so the site hosts a copy of
+# every source under /sources/<path> and the import points there instead.
+PAGES_BASE = "https://joshuafuller.github.io/ATAK-Maps"
+# Directory (relative to the MkDocs docs dir) the generator copies sources into.
+SOURCES_SUBDIR = "sources"
+
 EXCLUDE_DIRS = {
     ".github",
     ".git",
@@ -54,6 +64,10 @@ def build_map_entry(filepath: Path, root: Path, raw_base: str = RAW_BASE) -> dic
     source_type = SOURCE_TYPE_MAP.get(root_el.tag, root_el.tag)
     rel = filepath.relative_to(root).as_posix()
     raw_url = f"{raw_base}/{rel}"
+    # The import must fetch the XML with an application/xml content type; the
+    # Pages-hosted copy provides that (see PAGES_BASE note above). raw_url is
+    # kept only for the human-facing "view source" link.
+    import_url = f"{PAGES_BASE}/{SOURCES_SUBDIR}/{rel}"
     urls = " ".join((u.text or "") for u in root_el.iter("url"))
     return {
         "provider": provider,
@@ -61,7 +75,8 @@ def build_map_entry(filepath: Path, root: Path, raw_base: str = RAW_BASE) -> dic
         "source_type": source_type,
         "slug": slugify(f"{provider}-{filepath.stem}"),
         "raw_url": raw_url,
-        "import_uri": build_import_uri(raw_url),
+        "import_url": import_url,
+        "import_uri": build_import_uri(import_url),
         "needs_key": "API_KEY_HERE" in urls,
     }
 

--- a/scripts/gen_pages_catalog.py
+++ b/scripts/gen_pages_catalog.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Generate docs/maps.md and docs/qr/*.png from the repo's map sources."""
 
+import shutil
 import sys
 from pathlib import Path
 
@@ -13,6 +14,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from mapvalidator.catalog import (  # noqa: E402
+    SOURCES_SUBDIR,
     build_map_entry,
     iter_map_files,
     render_maps_page,
@@ -20,6 +22,7 @@ from mapvalidator.catalog import (  # noqa: E402
 
 DOCS = REPO_ROOT / "docs"
 QR_DIR = DOCS / "qr"
+SOURCES_DIR = DOCS / SOURCES_SUBDIR
 
 
 def write_qr(data: str, out_path: Path) -> None:
@@ -31,11 +34,22 @@ def write_qr(data: str, out_path: Path) -> None:
 
 
 def main() -> None:
-    entries = [build_map_entry(f, REPO_ROOT) for f in iter_map_files(REPO_ROOT)]
+    map_files = iter_map_files(REPO_ROOT)
+    entries = [build_map_entry(f, REPO_ROOT) for f in map_files]
     for e in entries:
         write_qr(e["import_uri"], QR_DIR / f"{e['slug']}.png")
+    # Publish a copy of each source XML on the site so ATAK fetches it with an
+    # application/xml content type (raw githubusercontent serves text/plain,
+    # which breaks ATAK's import — see mapvalidator.catalog.PAGES_BASE).
+    for f in map_files:
+        dest = SOURCES_DIR / f.relative_to(REPO_ROOT)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(f, dest)
     (DOCS / "maps.md").write_text(render_maps_page(entries))
-    print(f"Generated {len(entries)} map entries + QR codes into docs/.")
+    print(
+        f"Generated {len(entries)} map entries + QR codes + hosted sources "
+        "into docs/."
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -51,6 +51,17 @@ def test_build_map_entry_fields(tmp_path):
     assert e["raw_url"] == (
         "https://raw.example/repo/master/OrdnanceSurvey/os_road_3857.xml"
     )
+    # The import must target the Pages-hosted copy (served as application/xml),
+    # NOT raw githubusercontent (text/plain) — otherwise ATAK appends .txt and
+    # silently drops the map. See mapvalidator.catalog.PAGES_BASE.
+    assert e["import_url"] == (
+        "https://joshuafuller.github.io/ATAK-Maps/sources/"
+        "OrdnanceSurvey/os_road_3857.xml"
+    )
+    from urllib.parse import quote
+
+    assert quote(e["import_url"], safe="") in e["import_uri"]
+    assert "raw.githubusercontent" not in e["import_uri"]
     assert e["import_uri"].startswith("tak://com.atakmap.app/import?url=")
     assert e["needs_key"] is True
 


### PR DESCRIPTION
## Root cause (confirmed against TAK-Product-Center/atak-civ)

ATAK's `ImportFileDownloader` appends a file extension derived from the HTTP `Content-Type` when the downloaded filename doesn't already match it:
```java
MIMEType mt = ResourceFile.getMIMETypeForMIME(contentType);
if (mt != null && !fileName.endsWith("." + mt.EXT)) fileName += "." + mt.EXT;
```
`raw.githubusercontent.com` serves `.xml` as **`text/plain`**, and `ResourceFile` maps `TXT("text/plain","txt")` — so ATAK renamed `blm_land_ownership_sma.xml` → `…xml.txt`. No map-source resolver claims a `.txt`, so the import **silently no-op'd** (recognizes URL, downloads, nothing happens, no error). `MobacMapSourceLayerInfoSpi.probe()` parses `<customMapSource>` by content, so a real `.xml` *would* import.

## Fix

GitHub **Pages** serves `.xml` as `application/xml` (verified), which keeps the `.xml` extension. The generator now publishes a copy of every source under `/sources/<path>`, and each per-map `tak://` import targets that Pages URL instead of raw. `raw_url` is kept only for the human view-source link.

## Verification

154 tests pass; `mkdocs build --strict` clean; generator copies 40 source XMLs into `docs/sources/` (git-ignored) and import URIs now target `joshuafuller.github.io/…/sources/*.xml`. Final behavioural check is on-device (scan a per-map QR in ATAK 5.1+).

Note: the **bundle** `atak-maps.zip` is a separate path — a plain zip likely needs a data-package MANIFEST to import; follow-up.