### PR TITLE
feat: professional redesign — Maps catalog, landing page, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,62 @@
+<div align="center">
+
+<img src="https://github.com/joshuafuller/ATAK-Maps/blob/master/images/ATAK_MAPS_Logo.png?raw=true" alt="ATAK-Maps" width="440">
+
 # ATAK-Maps
 
-![ATAK-Maps Logo](https://github.com/joshuafuller/ATAK-Maps/blob/master/images/ATAK_MAPS_Logo.png?raw=true)
+**Install any map into [ATAK](https://tak.gov) in one tap.**
+
+A curated, open collection of **40** satellite, topographic, nautical, trail and
+overlay map sources — scan a QR, tap **Add to ATAK**, or side-load. No manual
+file wrangling. ATAK&nbsp;5.1+.
 
 [![Latest Release](https://img.shields.io/github/v/release/joshuafuller/ATAK-Maps?style=flat)](https://github.com/joshuafuller/ATAK-Maps/releases/latest) ![Release Date](https://img.shields.io/github/release-date/joshuafuller/ATAK-Maps?style=flat) [![Downloads](https://img.shields.io/github/downloads/joshuafuller/ATAK-Maps/total?style=flat)](https://github.com/joshuafuller/ATAK-Maps/releases/latest) [![XML Validation](https://img.shields.io/github/actions/workflow/status/joshuafuller/ATAK-Maps/validate-maps.yml?label=XML%20validation&style=flat)](https://github.com/joshuafuller/ATAK-Maps/actions/workflows/validate-maps.yml)
 [![Stars](https://img.shields.io/github/stars/joshuafuller/ATAK-Maps?style=flat)](https://github.com/joshuafuller/ATAK-Maps/stargazers) [![License](https://img.shields.io/github/license/joshuafuller/ATAK-Maps?style=flat)](LICENSE) [![Discord](https://img.shields.io/discord/698067185515495436?style=flat)](https://discord.gg/dQUYADMW87) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/joshuafuller/ATAK-Maps)
 
-## Detailed Overview of ATAK-Maps
+### [Browse &amp; install from the catalog site&nbsp;&rarr;](https://joshuafuller.github.io/ATAK-Maps/)
 
-ATAK-Maps is a comprehensive collection of XML files, formatted in the Mobile Atlas Creator (MOBAC) format. This format is used in [Android Tactical Assault Kit (ATAK)](https://tak.gov), an advanced geospatial mapping tool employed in various sectors including military, law enforcement, and emergency services. This repository and its contents are not affiliated with TAK.GOV in any way.
+</div>
 
-### What are ATAK-Maps?
+## Add to ATAK
 
-These XML files in ATAK-Maps act as pointers or references to a multitude of online map sources. By using these files, ATAK can seamlessly access and display current and relevant map imagery from these sources. This capability is vital for operations requiring up-to-date geospatial information.
+<table>
+<tr>
+<td width="180" align="center">
+<img src="images/add-to-atak.png" width="160" alt="QR code to add all maps to ATAK"><br>
+<sub>Scan to add all 40 maps</sub>
+</td>
+<td>
 
-### MOBAC Format
+**Fastest — per map:** open the **[catalog site](https://joshuafuller.github.io/ATAK-Maps/maps/)**
+on your ATAK device and tap **Add to ATAK** on any map (filter by style, or
+scan a QR from another screen).
 
-The MOBAC format is integral to the functionality of ATAK-Maps. It enables the definition of how ATAK accesses these online map sources. For more detailed information on the MOBAC format, visit [Mobile Atlas Creator](https://mobac.sourceforge.io/).
-
-### Usage and Functionality
-
-- **Dynamic Map Access**: ATAK-Maps facilitates the dynamic access of various map sources, ensuring that users have the most current imagery available for their operational needs.
-- **Offline Caching**: One of the key features of ATAK is its ability to cache these maps. With ATAK-Maps, users can download and store map areas for offline use, which is crucial in environments with limited or no internet access.
-- **Customization and Selection**: Users can also select specific areas and set the desired image quality for downloads, allowing for tailored map coverage based on operational requirements.
-
-## Installation Guide
-
-1. **Download** the latest `atak-maps.zip` from the [Releases page](https://github.com/joshuafuller/ATAK-Maps/releases).
-2. **Import** — open the ZIP in ATAK using the Import feature. Maps populate automatically.
-3. **Verify** the new maps appear in ATAK's map layer selector.
-
-For manual installation, troubleshooting, and offline caching, see the **[Install Guide](docs/install-guide.md)**.
-
-## Add to ATAK (QR)
-
-**Scan to install the whole map set.** On an ATAK 5.1+ device, scan this QR
-(from another screen) — ATAK downloads and imports an ATAK data package
-containing every map source:
-
-![Add all maps to ATAK](images/add-to-atak.png)
-
-Viewing this on the ATAK device itself? Paste this into the device browser:
+**Whole set at once:** scan the QR, or on the device paste this into a browser —
+it imports a data package with all 40 maps, kept in ATAK's Mission Package Tool
+so you can remove them later:
 
 `tak://com.atakmap.app/import?url=https%3A%2F%2Fjoshuafuller.github.io%2FATAK-Maps%2Fpack%2Fatak-maps-all.zip`
 
-The package is kept after import (it is not deleted on receive), so you can
-remove all the maps later by deleting it from ATAK's Mission Package Tool.
+**Manual:** download the latest `atak-maps.zip` from the
+[Releases page](https://github.com/joshuafuller/ATAK-Maps/releases) and open it
+with ATAK's Import feature. See the **[Install Guide](docs/install-guide.md)**
+for troubleshooting and offline caching.
 
-> GitHub can't make a `tak://` link tappable in this README. For per-map QR
-> codes and one-tap **Add to ATAK** buttons, visit the
-> **[ATAK-Maps site](https://joshuafuller.github.io/ATAK-Maps/maps/)**.
+</td>
+</tr>
+</table>
+
+> Requires ATAK 5.1+ (the version that added the `tak://` import scheme). GitHub
+> can't render a tappable `tak://` link here — use the QR or the catalog site,
+> where the buttons are tappable on-device.
+
+## What is ATAK-Maps?
+
+A collection of [MOBAC-format](https://mobac.sourceforge.io/) XML files, each a
+pointer to an online map/imagery source. [ATAK](https://tak.gov) reads them to
+display live imagery and **cache map areas for offline use** — essential where
+connectivity is limited. Pick a region and quality, and ATAK downloads it for
+the field. (Not affiliated with TAK.GOV.)
 
 ## Map Catalog
 

--- a/descriptions.yml
+++ b/descriptions.yml
@@ -1,0 +1,127 @@
+# Map catalog metadata for the Maps page, keyed by map slug.
+# Community-editable: add an entry when you add a map.
+#   category: one of Satellite | Topographic | Street | Nautical |
+#             Cycling | Overlay | Land use   (used for grouping/filter)
+#   text:     one-line description shown under the map
+# A missing slug just omits the card detail (the generator warns about it).
+
+blm-blm-land-ownership-sma:
+  category: Land use
+  text: "Federal & state land ownership shaded by managing agency (BLM, USFS, NPS, BIA, state, private) — opaque basemap, United States."
+blm-blm-satellite-land-ownership:
+  category: Land use
+  text: "Esri satellite imagery with BLM land-ownership colours blended on top at 50% — United States."
+bing-bing-hybrid:
+  category: Satellite
+  text: "Bing satellite imagery with roads and labels overlaid — global."
+bing-bing-maps:
+  category: Street
+  text: "Bing road/street map — global."
+bing-bing-satellite:
+  category: Satellite
+  text: "Bing satellite/aerial imagery, no labels — global."
+esri-esri-clarity:
+  category: Satellite
+  text: "Esri World Imagery (Clarity) — high-resolution satellite/aerial, global."
+esri-esri-nat-geo-world:
+  category: Street
+  text: "National Geographic-styled reference map — terrain, roads and boundaries, global."
+esri-esri-usa-topo-maps:
+  category: Topographic
+  text: "Esri USA Topo — classic USGS-style topographic quads, United States."
+esri-esri-world-topo:
+  category: Topographic
+  text: "Esri World Topographic — roads, terrain, boundaries and labels, global."
+grg-grg-fema-nfhl-flood-hazard-zones:
+  category: Overlay
+  text: "FEMA National Flood Hazard Layer — flood-zone overlay, transparent, United States."
+grg-grg-bc-wildfire-perimeters-current:
+  category: Overlay
+  text: "Current British Columbia wildfire perimeters (DataBC) — transparent overlay."
+grg-grg-blm-public-lands-overlay:
+  category: Overlay
+  text: "BLM public-lands ownership as a transparent overlay — colour = public land, clear = private."
+grg-grg-google-road-only-overlay:
+  category: Overlay
+  text: "Google roads and labels only, transparent — drop over any imagery basemap."
+grg-grg-google-terrain-shading-overlay:
+  category: Overlay
+  text: "Google terrain hillshade as a transparent overlay."
+grg-grg-waymarkedtrails-cycle-routes-overlay:
+  category: Cycling
+  text: "Signed cycle routes (WaymarkedTrails) as a transparent overlay — best coverage in Europe."
+google-google-hybrid:
+  category: Satellite
+  text: "Google satellite imagery with roads and labels — global."
+google-google-roadmap-alt:
+  category: Street
+  text: "Google road map, alternate styling — global."
+google-google-roadmap-no-poi:
+  category: Street
+  text: "Google road map with points-of-interest removed for cleaner streets — global."
+google-google-roadmap-standard:
+  category: Street
+  text: "Standard Google road/street map — global."
+google-google-satellite-only:
+  category: Satellite
+  text: "Google satellite/aerial imagery, no labels — global."
+google-google-terrain:
+  category: Topographic
+  text: "Google terrain map — shaded relief with roads, global."
+naip-naip-usda-conusprime:
+  category: Satellite
+  text: "USDA NAIP — high-resolution leaf-on aerial orthophotos, continental United States."
+naturalresourcescanada-naturalresourcescanada-cbmt:
+  category: Street
+  text: "Canada Base Map – Transportation (NRCan) — roads and reference, Canada."
+naturalresourcescanada-naturalresourcescanada-toporama:
+  category: Topographic
+  text: "Toporama (NRCan) — official Canadian topographic map."
+ordnancesurvey-os-light-3857:
+  category: Street
+  text: "Ordnance Survey Light — minimal low-contrast basemap of Great Britain. Free OS API key required."
+ordnancesurvey-os-outdoor-3857:
+  category: Topographic
+  text: "Ordnance Survey Outdoor — footpaths, contours and leisure detail, Great Britain. Free OS API key required."
+ordnancesurvey-os-road-3857:
+  category: Street
+  text: "Ordnance Survey Road — road/street map of Great Britain. Free OS API key required."
+poland-pl-geoportal-ortofoto-standard-epsg3857:
+  category: Satellite
+  text: "Polish Geoportal orthophoto — high-resolution aerial imagery, Poland."
+basemapde-basemapde-raster-farbe:
+  category: Street
+  text: "basemap.de raster (colour) — official German government topographic basemap."
+basemapde-basemapde-raster-grau:
+  category: Street
+  text: "basemap.de raster (grayscale) — muted German government basemap, good under overlays."
+cycleosm-cycleosm-osm-cycle:
+  category: Cycling
+  text: "CyclOSM — cycling-oriented OpenStreetMap style highlighting bike infrastructure, global."
+michelin-michelin-osm-michelin:
+  category: Street
+  text: "Michelin-styled OpenStreetMap road map — global."
+mtbmapcz-mtbmapcz-mtb-map-europe:
+  category: Cycling
+  text: "MTBMap.cz — mountain-bike map with singletrack and trail difficulty, Europe."
+openseamap-openseamap-base-chart:
+  category: Nautical
+  text: "OpenSeaMap base chart — OpenStreetMap land with marine styling."
+openseamap-openseamap-seamarks:
+  category: Nautical
+  text: "OpenSeaMap seamarks — buoys, lights and depths as a transparent overlay, global."
+opentopo-opentopo-opentopomap:
+  category: Topographic
+  text: "OpenTopoMap — topographic style over OSM with contours and hillshade, global."
+usgs-usgs-usgsbasemap:
+  category: Topographic
+  text: "USGS The National Map topographic basemap — United States."
+usgs-usgs-usgsimageryonly:
+  category: Satellite
+  text: "USGS aerial imagery only, no labels — United States."
+usgs-usgs-usgsimagerytopo:
+  category: Satellite
+  text: "USGS aerial imagery with topographic labels and features blended — United States."
+usgs-usgs-usgsshadedrelief:
+  category: Topographic
+  text: "USGS shaded relief — terrain hillshade, United States."

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,16 +1,50 @@
-# ATAK-Maps
+<section class="am-landing" markdown="0">
+  <p class="am-landing__eyebrow">Map sources for ATAK</p>
+  <h1>Install any map into ATAK in one tap.</h1>
+  <p class="am-landing__lede">A curated, open collection of 40 map and imagery
+  sources — satellite, topographic, nautical, trail and more. Scan a QR code or
+  tap <b>Add to ATAK</b>; no manual file wrangling. ATAK&nbsp;5.1+.</p>
+  <div class="am-cta">
+    <a class="am-btn am-btn--all" href="maps/">Browse the maps</a>
+    <a class="am-btn am-btn--ghost" href="tak://com.atakmap.app/import?url=https%3A%2F%2Fjoshuafuller.github.io%2FATAK-Maps%2Fpack%2Fatak-maps-all.zip">Add all 40 maps to ATAK</a>
+  </div>
+</section>
 
-A curated collection of map sources for [ATAK](https://tak.gov) — scan a QR
-code or tap **Add to ATAK** to install a map in seconds (ATAK 5.1+).
-
-- **[Browse the maps](maps.md)** — every source with a QR code and one-tap install.
-- **[Installation guide](install-guide.md)** — manual install and troubleshooting.
-- **[Create your own](creating-custom-maps.md)** — the MOBAC XML format.
+<div class="am-features" markdown="0">
+  <div class="am-feature">
+    <div class="am-feature__k">40</div>
+    <h3>Curated sources</h3>
+    <p>Satellite, topographic, street, nautical, cycling and thematic overlays — validated and kept live.</p>
+  </div>
+  <div class="am-feature">
+    <div class="am-feature__k">1&nbsp;tap</div>
+    <h3>Zero setup</h3>
+    <p>Every map has a QR code and an <b>Add to ATAK</b> link that installs it directly on the device.</p>
+  </div>
+  <div class="am-feature">
+    <div class="am-feature__k">1&nbsp;pack</div>
+    <h3>Or all at once</h3>
+    <p>Install the entire set as a single ATAK data package — kept in the Mission Package Tool so it is easy to remove.</p>
+  </div>
+</div>
 
 ## Install the whole set
 
-Scan this (or, on the device, tap **[Add all maps to ATAK](tak://com.atakmap.app/import?url=https%3A%2F%2Fjoshuafuller.github.io%2FATAK-Maps%2Fpack%2Fatak-maps-all.zip)**) to import an ATAK data package with every map source:
+<section class="am-hero" markdown="0">
+  <div class="am-hero__body">
+    <h2>One package, every map</h2>
+    <p>Tap the button on your ATAK device, or scan the code from another
+    device. Imports a data package with all 40 sources.</p>
+    <a class="am-btn am-btn--all" href="tak://com.atakmap.app/import?url=https%3A%2F%2Fjoshuafuller.github.io%2FATAK-Maps%2Fpack%2Fatak-maps-all.zip">Add all 40 maps to ATAK</a>
+    <p class="am-hero__note">Kept after import — remove everything later by deleting the package in ATAK’s Mission Package Tool.</p>
+  </div>
+  <img class="am-hero__qr" src="images/add-to-atak.png" alt="QR code to add all maps to ATAK">
+</section>
 
-![Add all maps to ATAK](images/add-to-atak.png)
+## Explore
 
-The package is kept after import, so you can remove all the maps later by deleting it from ATAK's Mission Package Tool. Prefer a manual install? [Download the raw bundle](https://github.com/joshuafuller/ATAK-Maps/releases/latest/download/atak-maps.zip).
+- **[Browse every map](maps/)** — filter by style, scan or tap to install.
+- **[Installation guide](install-guide.md)** — manual install and troubleshooting.
+- **[Create your own](creating-custom-maps.md)** — the MOBAC XML format, explained.
+
+Prefer a manual install? [Download the raw bundle](https://github.com/joshuafuller/ATAK-Maps/releases/latest/download/atak-maps.zip) and side-load it.

--- a/docs/javascripts/maps-filter.js
+++ b/docs/javascripts/maps-filter.js
@@ -1,0 +1,46 @@
+/* Maps page: filter cards by category chip + free-text search.
+   Hooks Material's document$ so it survives instant navigation. */
+(function () {
+  function init() {
+    var filter = document.querySelector(".am-filter");
+    if (!filter || filter.dataset.wired) return;
+    filter.dataset.wired = "1";
+
+    var grid = document.querySelector(".am-grid");
+    var empty = document.querySelector(".am-empty");
+    var search = filter.querySelector(".am-search");
+    var chips = Array.prototype.slice.call(filter.querySelectorAll(".am-chip"));
+    var cards = grid ? Array.prototype.slice.call(grid.querySelectorAll(".am-card")) : [];
+    var activeCat = "all";
+
+    function apply() {
+      var q = (search.value || "").trim().toLowerCase();
+      var shown = 0;
+      cards.forEach(function (card) {
+        var catOk = activeCat === "all" || card.dataset.cat === activeCat;
+        var textOk = !q || (card.dataset.search || "").indexOf(q) !== -1;
+        var visible = catOk && textOk;
+        card.classList.toggle("is-hidden", !visible);
+        if (visible) shown++;
+      });
+      if (empty) empty.hidden = shown !== 0;
+    }
+
+    chips.forEach(function (chip) {
+      chip.addEventListener("click", function () {
+        chips.forEach(function (c) { c.classList.remove("is-active"); });
+        chip.classList.add("is-active");
+        activeCat = chip.dataset.cat;
+        apply();
+      });
+    });
+    search.addEventListener("input", apply);
+    apply();
+  }
+
+  if (typeof window.document$ !== "undefined" && window.document$.subscribe) {
+    window.document$.subscribe(init);
+  } else {
+    document.addEventListener("DOMContentLoaded", init);
+  }
+})();

--- a/docs/stylesheets/maps.css
+++ b/docs/stylesheets/maps.css
@@ -1,0 +1,222 @@
+/* ATAK-Maps — Maps catalog page. Tactical field catalog: high-contrast,
+   category-coded, one signal action colour. Theme-aware (light + dark). */
+
+:root {
+  --am-action: #e8590c;
+  --am-action-hover: #ff7a2f;
+  --am-radius: 12px;
+  --am-card-bg: var(--md-default-bg-color);
+  --am-line: color-mix(in srgb, var(--md-default-fg-color) 14%, transparent);
+  --am-line-strong: color-mix(in srgb, var(--md-default-fg-color) 26%, transparent);
+  --am-muted: var(--md-default-fg-color--light);
+}
+[data-md-color-scheme="slate"] {
+  --am-action: #ff7a2f;
+  --am-action-hover: #ff8f4d;
+  --am-card-bg: color-mix(in srgb, var(--md-default-fg-color) 5%, var(--md-default-bg-color));
+}
+
+/* ---- Install-everything hero ---- */
+.am-hero {
+  display: flex;
+  gap: 1.6rem;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  margin: 1.2rem 0 1.6rem;
+  padding: 1.4rem 1.6rem;
+  border: 1px solid var(--am-line-strong);
+  border-radius: var(--am-radius);
+  background:
+    radial-gradient(120% 140% at 100% 0%,
+      color-mix(in srgb, var(--am-action) 12%, transparent), transparent 60%),
+    var(--am-card-bg);
+}
+.am-hero__body { flex: 1 1 320px; }
+.am-hero h2 { margin: 0 0 .35rem; font-weight: 700; letter-spacing: -.01em; }
+.am-hero p { margin: .25rem 0; }
+.am-hero__note { color: var(--am-muted); font-size: .8rem; }
+.am-hero__qr {
+  width: 148px; height: 148px; border-radius: 10px; background: #fff;
+  padding: 8px; box-shadow: 0 6px 24px rgba(0,0,0,.18); flex: 0 0 auto;
+}
+
+/* ---- How it works ---- */
+.am-how {
+  display: flex; flex-wrap: wrap; gap: .6rem 1.4rem;
+  margin: 0 0 1.2rem; padding: .7rem 1rem;
+  border-left: 3px solid var(--am-action);
+  background: color-mix(in srgb, var(--am-action) 6%, transparent);
+  border-radius: 0 8px 8px 0; font-size: .82rem;
+}
+.am-how__step { display: flex; align-items: center; gap: .5rem; }
+.am-how__step > span {
+  display: grid; place-items: center; width: 1.35rem; height: 1.35rem;
+  border-radius: 50%; background: var(--am-action); color: #fff;
+  font-weight: 700; font-size: .72rem; flex: 0 0 auto;
+}
+
+/* ---- Filter bar ---- */
+.am-filter {
+  position: sticky; top: 2.4rem; z-index: 3;
+  display: flex; flex-wrap: wrap; gap: .6rem; align-items: center;
+  margin: 0 0 1.1rem; padding: .5rem 0;
+  background: var(--md-default-bg-color);
+}
+.am-search {
+  flex: 1 1 220px; min-width: 180px;
+  padding: .5rem .8rem; font: inherit; color: inherit;
+  border: 1px solid var(--am-line-strong); border-radius: 999px;
+  background: var(--am-card-bg);
+}
+.am-search:focus { outline: 2px solid var(--am-action); outline-offset: 1px; }
+.am-chips { display: flex; flex-wrap: wrap; gap: .4rem; }
+.am-chip {
+  padding: .32rem .78rem; font: inherit; font-size: .78rem; font-weight: 600;
+  color: var(--am-muted); cursor: pointer;
+  border: 1px solid var(--am-line-strong); border-radius: 999px;
+  background: transparent; transition: all .12s ease;
+}
+.am-chip:hover { border-color: var(--am-action); color: var(--md-default-fg-color); }
+.am-chip.is-active {
+  background: var(--am-action); border-color: var(--am-action); color: #fff;
+}
+.am-empty { color: var(--am-muted); font-style: italic; }
+
+/* ---- Card grid ---- */
+.am-grid {
+  display: grid; gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(290px, 1fr));
+}
+.am-card {
+  display: flex; flex-direction: column;
+  border: 1px solid var(--am-line); border-radius: var(--am-radius);
+  background: var(--am-card-bg); padding: 1rem 1rem .85rem;
+  transition: transform .14s ease, border-color .14s ease, box-shadow .14s ease;
+  animation: am-in .4s ease both;
+}
+.am-card:hover {
+  transform: translateY(-3px); border-color: var(--am-line-strong);
+  box-shadow: 0 10px 30px color-mix(in srgb, var(--md-default-fg-color) 10%, transparent);
+}
+.am-card__top { display: flex; align-items: center; justify-content: space-between; }
+.am-type {
+  font-family: var(--md-code-font, monospace); font-size: .66rem;
+  letter-spacing: .06em; color: var(--am-muted);
+}
+.am-card__name { margin: .5rem 0 .3rem; font-size: 1.02rem; line-height: 1.25; }
+.am-card__desc {
+  margin: 0 0 .85rem; font-size: .84rem; line-height: 1.45;
+  color: var(--md-default-fg-color--light); flex: 1 1 auto;
+}
+.am-card__actions { display: flex; align-items: center; gap: .7rem; }
+.am-card__qr {
+  width: 58px; height: 58px; border-radius: 7px; background: #fff; padding: 4px;
+  flex: 0 0 auto; border: 1px solid var(--am-line);
+}
+.am-card__foot {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-top: .7rem; padding-top: .55rem; border-top: 1px solid var(--am-line);
+  font-size: .74rem;
+}
+.am-card__foot a { color: var(--am-muted); }
+.am-card__key {
+  font-size: .66rem; font-weight: 700; letter-spacing: .04em; text-transform: uppercase;
+  color: var(--am-action);
+  border: 1px solid color-mix(in srgb, var(--am-action) 45%, transparent);
+  border-radius: 999px; padding: .1rem .5rem;
+}
+
+/* ---- Action buttons ---- */
+.am-btn {
+  display: inline-flex; align-items: center; gap: .45rem;
+  padding: .55rem .9rem; font-weight: 700; font-size: .84rem; line-height: 1;
+  color: #fff !important; background: var(--am-action);
+  border-radius: 8px; text-decoration: none; white-space: nowrap;
+  transition: background .12s ease, transform .08s ease;
+}
+.am-btn:hover { background: var(--am-action-hover); }
+.am-btn:active { transform: scale(.97); }
+.am-btn svg { width: 16px; height: 16px; stroke: currentColor; stroke-width: 2.4;
+  fill: none; stroke-linecap: round; }
+.am-btn--add { flex: 1 1 auto; justify-content: center; }
+.am-btn--all { font-size: .95rem; padding: .7rem 1.2rem; margin-top: .4rem; }
+
+/* ---- Category badge colours ---- */
+.am-badge {
+  font-size: .66rem; font-weight: 700; letter-spacing: .04em; text-transform: uppercase;
+  padding: .18rem .55rem; border-radius: 999px;
+  background: color-mix(in srgb, var(--_c) 18%, transparent);
+  color: color-mix(in srgb, var(--_c) 72%, var(--md-default-fg-color));
+  border: 1px solid color-mix(in srgb, var(--_c) 40%, transparent);
+}
+.am-badge--satellite   { --_c: #0ea5a5; }
+.am-badge--topographic { --_c: #2f9e44; }
+.am-badge--street      { --_c: #4c6ef5; }
+.am-badge--nautical    { --_c: #1c7ed6; }
+.am-badge--cycling     { --_c: #ae3ec9; }
+.am-badge--overlay     { --_c: #f08c00; }
+.am-badge--land-use    { --_c: #a1662f; }
+.am-badge--other       { --_c: #868e96; }
+
+.am-card.is-hidden { display: none; }
+
+@keyframes am-in { from { opacity: 0; transform: translateY(8px); } }
+@media (prefers-reduced-motion: reduce) {
+  .am-card { animation: none; }
+  .am-card:hover { transform: none; }
+}
+
+/* ---- Landing page ---- */
+.am-landing {
+  position: relative;
+  margin: 0 0 2rem; padding: 2.6rem 1.8rem 2.2rem;
+  border: 1px solid var(--am-line-strong); border-radius: 16px;
+  overflow: hidden;
+  background:
+    radial-gradient(90% 120% at 0% 0%,
+      color-mix(in srgb, var(--am-action) 14%, transparent), transparent 55%),
+    var(--am-card-bg);
+}
+.am-landing::before {
+  content: ""; position: absolute; inset: 0; pointer-events: none;
+  background-image:
+    linear-gradient(color-mix(in srgb, var(--md-default-fg-color) 6%, transparent) 1px, transparent 1px),
+    linear-gradient(90deg, color-mix(in srgb, var(--md-default-fg-color) 6%, transparent) 1px, transparent 1px);
+  background-size: 28px 28px; mask-image: radial-gradient(80% 80% at 100% 100%, #000, transparent 75%);
+  opacity: .5;
+}
+.am-landing__eyebrow {
+  font-family: var(--md-code-font, monospace); font-size: .72rem;
+  letter-spacing: .22em; text-transform: uppercase; color: var(--am-action);
+  margin: 0 0 .5rem;
+}
+.am-landing h1 {
+  margin: 0 0 .6rem; font-size: clamp(2rem, 5vw, 3.1rem); line-height: 1.04;
+  letter-spacing: -.02em; font-weight: 700;
+}
+.am-landing__lede {
+  max-width: 46ch; font-size: 1.05rem; color: var(--md-default-fg-color--light);
+  margin: 0 0 1.3rem;
+}
+.am-cta { display: flex; flex-wrap: wrap; gap: .7rem; align-items: center; }
+.am-btn--ghost {
+  background: transparent; color: var(--md-default-fg-color) !important;
+  border: 1px solid var(--am-line-strong);
+}
+.am-btn--ghost:hover { background: color-mix(in srgb, var(--md-default-fg-color) 6%, transparent); }
+
+.am-features {
+  display: grid; gap: 1rem; margin: 0 0 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+.am-feature {
+  padding: 1.1rem 1.2rem; border: 1px solid var(--am-line);
+  border-radius: var(--am-radius); background: var(--am-card-bg);
+}
+.am-feature h3 { margin: .1rem 0 .35rem; font-size: 1rem; }
+.am-feature p { margin: 0; font-size: .86rem; color: var(--md-default-fg-color--light); }
+.am-feature__k {
+  font-family: var(--md-code-font, monospace); font-size: 1.7rem; font-weight: 700;
+  color: var(--am-action); line-height: 1;
+}

--- a/mapvalidator/catalog.py
+++ b/mapvalidator/catalog.py
@@ -1,11 +1,23 @@
 """Turn map XML files into catalog entries and the Maps markdown page."""
 
+import html
 import os
 import re
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
 from mapvalidator.qr import build_import_uri
+
+# Display/filter order for the map style categories on the Maps page.
+CATEGORY_ORDER = [
+    "Satellite",
+    "Topographic",
+    "Street",
+    "Nautical",
+    "Cycling",
+    "Overlay",
+    "Land use",
+]
 
 RAW_BASE = "https://raw.githubusercontent.com/joshuafuller/ATAK-Maps/master"
 
@@ -120,33 +132,144 @@ def build_map_entry(filepath: Path, root: Path, raw_base: str = RAW_BASE) -> dic
     }
 
 
-def render_maps_page(entries: list[dict]) -> str:
-    """Render the Maps markdown page grouped by provider."""
-    lines = [
-        "# Maps",
-        "",
-        "Scan a QR code with another device, or tap **Add to ATAK** on this "
-        "device (requires ATAK 5.1+). Confirm the import prompt in ATAK.",
-        "",
-    ]
-    provider = None
-    for e in sorted(entries, key=lambda x: (x["provider"].lower(), x["name"].lower())):
-        if e["provider"] != provider:
-            provider = e["provider"]
-            lines += [f"## {provider}", ""]
-        lines += [
-            f"### {e['name']}",
-            "",
-            f"![QR for {e['name']}](qr/{e['slug']}.png)",
-            "",
-            f"[Add to ATAK]({e['import_uri']}) &nbsp;·&nbsp; "
-            f"[Download XML]({e['raw_url']})",
+_ADD_ICON = (
+    '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">'
+    '<path d="M12 5v14M5 12h14"/></svg>'
+)
+
+
+def _cat_class(category: str) -> str:
+    """CSS modifier for a category, e.g. 'Land use' -> 'land-use'."""
+    return slugify(category) or "other"
+
+
+def _card_html(entry: dict, meta: dict) -> str:
+    """Render one map as a card. ``meta`` is {category, text} or {}."""
+    name = html.escape(entry["name"])
+    category = meta.get("category") or "Other"
+    desc = html.escape(meta.get("text") or "")
+    # data-search powers the on-page filter (name + description + provider).
+    search = html.escape(
+        " ".join((entry["name"], meta.get("text") or "", entry["provider"])).lower(),
+        quote=True,
+    )
+    key_badge = (
+        '<span class="am-card__key" title="Requires a free API key">key required</span>'
+        if entry["needs_key"]
+        else ""
+    )
+    add_href = html.escape(entry["import_uri"], quote=True)
+    src_href = html.escape(entry["raw_url"], quote=True)
+    return (
+        f'<article class="am-card" data-cat="{html.escape(category, quote=True)}" '
+        f'data-search="{search}">'
+        '<div class="am-card__top">'
+        f'<span class="am-badge am-badge--{_cat_class(category)}">'
+        f"{html.escape(category)}</span>"
+        f'<span class="am-type">{html.escape(entry["source_type"])}</span>'
+        "</div>"
+        f'<h3 class="am-card__name">{name}</h3>'
+        f'<p class="am-card__desc">{desc}</p>'
+        '<div class="am-card__actions">'
+        f'<a class="am-btn am-btn--add" href="{add_href}">'
+        f"{_ADD_ICON}<span>Add to ATAK</span></a>"
+        f'<img class="am-card__qr" src="../qr/{entry["slug"]}.png" '
+        f'alt="QR code to add {name} to ATAK" loading="lazy" '
+        'title="Scan from another device">'
+        "</div>"
+        '<div class="am-card__foot">'
+        f'<a href="{src_href}">View source</a>'
+        f"{key_badge}"
+        "</div>"
+        "</article>"
+    )
+
+
+def render_maps_page(
+    entries: list[dict],
+    descriptions: dict | None = None,
+    package_uri: str | None = None,
+    package_qr: str | None = None,
+) -> str:
+    """Render the Maps page: an install hero, a category filter, and a card grid.
+
+    ``descriptions`` maps slug -> {category, text}. ``package_uri`` and
+    ``package_qr`` (when given) render the "install everything" hero for the
+    whole-map-pack data package.
+    """
+    descriptions = descriptions or {}
+    ordered = sorted(entries, key=lambda x: (x["provider"].lower(), x["name"].lower()))
+    total = len(ordered)
+
+    out = ["# Maps", ""]
+
+    # Install-everything hero.
+    if package_uri and package_qr:
+        pkg_href = html.escape(package_uri, quote=True)
+        pkg_qr = html.escape(package_qr, quote=True)
+        out += [
+            '<section class="am-hero">',
+            '  <div class="am-hero__body">',
+            "    <h2>Install every map at once</h2>",
+            f"    <p>Tap the button on your ATAK device, or scan the code from "
+            f"another device. Imports one data package with all {total} maps "
+            f"(ATAK&nbsp;5.1+).</p>",
+            f'    <a class="am-btn am-btn--all" href="{pkg_href}">'
+            f"{_ADD_ICON}<span>Add all {total} maps to ATAK</span></a>",
+            '    <p class="am-hero__note">Kept in ATAK’s Mission Package '
+            "Tool, so you can remove them all later by deleting the package.</p>",
+            "  </div>",
+            f'  <img class="am-hero__qr" src="{pkg_qr}" '
+            'alt="QR code to add all maps to ATAK">',
+            "</section>",
             "",
         ]
-        if e["needs_key"]:
-            lines += [
-                "> Requires a free API key — open the source file for setup "
-                "instructions.",
-                "",
-            ]
-    return "\n".join(lines)
+
+    # How-it-works.
+    out += [
+        '<div class="am-how">',
+        '  <div class="am-how__step"><span>1</span> On your ATAK device, tap '
+        "<b>Add to ATAK</b> and confirm the prompt.</div>",
+        '  <div class="am-how__step"><span>2</span> From another device, scan '
+        "the <b>QR code</b> with ATAK.</div>",
+        "</div>",
+        "",
+    ]
+
+    # Filter bar: search box + category chips (only for categories present).
+    present = [
+        c
+        for c in CATEGORY_ORDER
+        if any(
+            (descriptions.get(e["slug"]) or {}).get("category") == c for e in ordered
+        )
+    ]
+    chips = ['<button class="am-chip is-active" data-cat="all">All</button>']
+    chips += [
+        f'<button class="am-chip" data-cat="{html.escape(c, quote=True)}">'
+        f"{html.escape(c)}</button>"
+        for c in present
+    ]
+    out += [
+        '<div class="am-filter">',
+        '  <input class="am-search" type="search" placeholder="Filter maps…" '
+        'aria-label="Filter maps by name">',
+        '  <div class="am-chips">' + "".join(chips) + "</div>",
+        "</div>",
+        '<p class="am-empty" hidden>No maps match your filter.</p>',
+        "",
+    ]
+
+    # Card grid.
+    missing = [e for e in ordered if not descriptions.get(e["slug"])]
+    cards = [_card_html(e, descriptions.get(e["slug"]) or {}) for e in ordered]
+    out += ['<div class="am-grid">', *cards, "</div>"]
+
+    if missing:
+        out += [
+            "",
+            f"<!-- {len(missing)} maps without a description entry: "
+            + ", ".join(e["slug"] for e in missing)
+            + " -->",
+        ]
+    return "\n".join(out)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,9 @@ theme:
   name: material
   logo: images/atak-maps-logo.png
   favicon: images/atak-maps-logo.png
+  font:
+    text: IBM Plex Sans
+    code: IBM Plex Mono
   palette:
     - scheme: default
       primary: blue grey
@@ -35,6 +38,16 @@ nav:
 
 exclude_docs: |
   superpowers/
+
+markdown_extensions:
+  - attr_list
+  - md_in_html
+
+extra_css:
+  - stylesheets/maps.css
+
+extra_javascript:
+  - javascripts/maps-filter.js
 
 plugins:
   - search

--- a/scripts/gen_pages_catalog.py
+++ b/scripts/gen_pages_catalog.py
@@ -21,6 +21,7 @@ from mapvalidator.catalog import (  # noqa: E402
     build_manifest,
     build_map_entry,
     iter_map_files,
+    package_import_uri,
     render_maps_page,
 )
 
@@ -28,6 +29,9 @@ DOCS = REPO_ROOT / "docs"
 QR_DIR = DOCS / "qr"
 SOURCES_DIR = DOCS / SOURCES_SUBDIR
 PACKAGE_DIR = DOCS / PACKAGE_SUBDIR
+DESCRIPTIONS_FILE = REPO_ROOT / "descriptions.yml"
+# The Maps page renders at /maps/ (pretty URLs); assets live one level up.
+ALL_MAPS_QR = "../qr/_all-maps.png"
 
 
 def write_qr(data: str, out_path: Path) -> None:
@@ -36,6 +40,15 @@ def write_qr(data: str, out_path: Path) -> None:
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
     qrcode.make(data).save(out_path)
+
+
+def load_descriptions() -> dict:
+    """Load descriptions.yml (slug -> {category, text}); {} if absent."""
+    if not DESCRIPTIONS_FILE.exists():
+        return {}
+    import yaml
+
+    return yaml.safe_load(DESCRIPTIONS_FILE.read_text()) or {}
 
 
 def build_data_package(map_files: list[Path], out_zip: Path) -> None:
@@ -66,7 +79,20 @@ def main() -> None:
         dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(f, dest)
     build_data_package(map_files, PACKAGE_DIR / PACKAGE_FILENAME)
-    (DOCS / "maps.md").write_text(render_maps_page(entries))
+    # QR for the whole-map-pack, shown in the Maps-page hero.
+    write_qr(package_import_uri(), QR_DIR / "_all-maps.png")
+    descriptions = load_descriptions()
+    missing = [e["slug"] for e in entries if not descriptions.get(e["slug"])]
+    if missing:
+        print(f"WARNING: {len(missing)} maps without a description: {missing}")
+    (DOCS / "maps.md").write_text(
+        render_maps_page(
+            entries,
+            descriptions=descriptions,
+            package_uri=package_import_uri(),
+            package_qr=ALL_MAPS_QR,
+        )
+    )
     print(
         f"Generated {len(entries)} map entries + QR codes + hosted sources + "
         "data package into docs/."

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -66,24 +66,37 @@ def test_build_map_entry_fields(tmp_path):
     assert e["needs_key"] is True
 
 
-def test_render_maps_page_structure():
-    entries = [
-        {
-            "provider": "OrdnanceSurvey",
-            "name": "OS - Road 3857",
-            "source_type": "TMS",
-            "slug": "ordnancesurvey-os-road-3857",
-            "raw_url": "https://raw.example/os.xml",
-            "import_uri": "tak://com.atakmap.app/import?url=ENC",
-            "needs_key": True,
+_OS_ENTRY = {
+    "provider": "OrdnanceSurvey",
+    "name": "OS - Road 3857",
+    "source_type": "TMS",
+    "slug": "ordnancesurvey-os-road-3857",
+    "raw_url": "https://raw.example/os.xml",
+    "import_uri": "tak://com.atakmap.app/import?url=ENC",
+    "needs_key": True,
+}
+
+
+def test_render_maps_page_card_html():
+    descriptions = {
+        "ordnancesurvey-os-road-3857": {
+            "category": "Street",
+            "text": "OS road map of Great Britain.",
         }
-    ]
-    md = render_maps_page(entries)
-    assert "## OrdnanceSurvey" in md
-    assert "![QR for OS - Road 3857](qr/ordnancesurvey-os-road-3857.png)" in md
-    assert "[Add to ATAK](tak://com.atakmap.app/import?url=ENC)" in md
-    assert "[Download XML](https://raw.example/os.xml)" in md
-    assert "Requires a free API key" in md
+    }
+    md = render_maps_page([_OS_ENTRY], descriptions=descriptions)
+    assert 'class="am-card"' in md
+    assert 'data-cat="Street"' in md
+    assert "am-badge--street" in md
+    assert "OS road map of Great Britain." in md
+    # the Add-to-ATAK button links the import URI
+    assert 'href="tak://com.atakmap.app/import?url=ENC"' in md
+    assert "Add to ATAK" in md
+    assert "qr/ordnancesurvey-os-road-3857.png" in md
+    assert 'href="https://raw.example/os.xml"' in md  # view source
+    assert "key required" in md  # needs_key badge
+    # a Street filter chip is present
+    assert '<button class="am-chip" data-cat="Street">Street</button>' in md
 
 
 def test_iter_map_files_skips_dot_directories(tmp_path):
@@ -94,45 +107,41 @@ def test_iter_map_files_skips_dot_directories(tmp_path):
     assert "sitemap.xml" not in names
 
 
-def test_render_maps_page_no_key_note_when_not_needed():
-    entries = [
-        {
-            "provider": "USGS",
-            "name": "USGS Topo",
-            "source_type": "TMS",
-            "slug": "usgs-topo",
-            "raw_url": "https://raw.example/usgs.xml",
-            "import_uri": "tak://com.atakmap.app/import?url=ENC",
-            "needs_key": False,
-        }
-    ]
-    md = render_maps_page(entries)
-    assert "Requires a free API key" not in md
+_USGS_ENTRY = {
+    "provider": "USGS",
+    "name": "USGS Topo",
+    "source_type": "TMS",
+    "slug": "usgs-topo",
+    "raw_url": "https://raw.example/usgs.xml",
+    "import_uri": "tak://com.atakmap.app/import?url=ENC",
+    "needs_key": False,
+}
 
 
-def test_render_maps_page_provider_heading_deduped():
-    entries = [
-        {
-            "provider": "ESRI",
-            "name": "A",
-            "source_type": "TMS",
-            "slug": "esri-a",
-            "raw_url": "https://x/a.xml",
-            "import_uri": "tak://com.atakmap.app/import?url=A",
-            "needs_key": False,
-        },
-        {
-            "provider": "ESRI",
-            "name": "B",
-            "source_type": "TMS",
-            "slug": "esri-b",
-            "raw_url": "https://x/b.xml",
-            "import_uri": "tak://com.atakmap.app/import?url=B",
-            "needs_key": False,
-        },
-    ]
-    md = render_maps_page(entries)
-    assert md.count("## ESRI") == 1
+def test_render_maps_page_no_key_badge_when_not_needed():
+    md = render_maps_page(
+        [_USGS_ENTRY],
+        descriptions={"usgs-topo": {"category": "Topographic", "text": "t"}},
+    )
+    assert "key required" not in md
+
+
+def test_render_maps_page_hero_when_package_given():
+    md = render_maps_page(
+        [_USGS_ENTRY],
+        descriptions={},
+        package_uri="tak://com.atakmap.app/import?url=PKG",
+        package_qr="qr/_all-maps.png",
+    )
+    assert "am-hero" in md
+    assert 'href="tak://com.atakmap.app/import?url=PKG"' in md
+    assert "qr/_all-maps.png" in md
+    assert "Add all 1 maps to ATAK" in md
+
+
+def test_render_maps_page_no_hero_without_package():
+    md = render_maps_page([_USGS_ENTRY])
+    assert "am-hero" not in md
 
 
 def test_build_manifest_structure():


### PR DESCRIPTION
Makes the site an install-first experience.

**Maps page** — install-everything hero (whole-pack QR + Add-all button), a filter bar (free-text search + style-category chips), and a responsive **card grid**: each map has a colour-coded category badge, a one-line description, a prominent **Add to ATAK** button, a scannable QR, and a *key required* flag. Curated one-line descriptions + categories live in a community-editable `descriptions.yml`.

**Landing page** — hero, feature highlights, whole-set install block, tappable links.

**Design system** — `docs/stylesheets/maps.css` (tactical, theme-aware light/dark), IBM Plex typography, client-side filter JS.

**README** — centred header, a clear 3-path install table (per-map site / whole-pack data package / manual), concise intro.

Verified locally with Playwright screenshots (light + dark), 157 tests, `mkdocs build --strict`. Also fixes raw-HTML QR paths to resolve from the `/maps/` pretty-URL directory.