### PR TITLE
fix(ui): scannable QR codes — lightbox on site, larger README QR

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ file wrangling. ATAK&nbsp;5.1+.
 
 <table>
 <tr>
-<td width="180" align="center">
-<img src="images/add-to-atak.png" width="160" alt="QR code to add all maps to ATAK"><br>
+<td width="260" align="center">
+<img src="images/add-to-atak.png" width="240" alt="QR code to add all maps to ATAK"><br>
 <sub>Scan to add all 40 maps</sub>
 </td>
 <td>

--- a/docs/javascripts/maps-filter.js
+++ b/docs/javascripts/maps-filter.js
@@ -36,6 +36,40 @@
     });
     search.addEventListener("input", apply);
     apply();
+
+    wireLightbox();
+  }
+
+  // Tap any small QR to open a large, scannable version.
+  function wireLightbox() {
+    var lb = document.querySelector(".am-lightbox");
+    if (!lb || lb.dataset.wired) return;
+    lb.dataset.wired = "1";
+    var img = lb.querySelector(".am-lightbox__img");
+    var cap = lb.querySelector(".am-lightbox__cap");
+
+    function open(qr) {
+      img.src = qr.getAttribute("src");
+      cap.textContent = (qr.getAttribute("alt") || "").replace(/^QR code to /, "");
+      lb.classList.add("is-open");
+    }
+    function close() { lb.classList.remove("is-open"); img.src = ""; }
+
+    document.querySelectorAll("img.am-card__qr, img.am-hero__qr").forEach(function (qr) {
+      qr.addEventListener("click", function () { open(qr); });
+    });
+    lb.addEventListener("click", function (e) {
+      if (e.target === lb || e.target.classList.contains("am-lightbox__close")) close();
+    });
+    if (!window.__amLbKey) {
+      window.__amLbKey = true;
+      document.addEventListener("keydown", function (e) {
+        if (e.key === "Escape") {
+          var open = document.querySelector(".am-lightbox.is-open");
+          if (open) open.classList.remove("is-open");
+        }
+      });
+    }
   }
 
   if (typeof window.document$ !== "undefined" && window.document$.subscribe) {

--- a/docs/stylesheets/maps.css
+++ b/docs/stylesheets/maps.css
@@ -111,9 +111,15 @@
 }
 .am-card__actions { display: flex; align-items: center; gap: .7rem; }
 .am-card__qr {
-  width: 58px; height: 58px; border-radius: 7px; background: #fff; padding: 4px;
+  width: 66px; height: 66px; border-radius: 7px; background: #fff; padding: 4px;
   flex: 0 0 auto; border: 1px solid var(--am-line);
+  cursor: zoom-in; transition: transform .12s ease, box-shadow .12s ease;
 }
+.am-card__qr:hover {
+  transform: scale(1.08);
+  box-shadow: 0 4px 14px color-mix(in srgb, var(--md-default-fg-color) 22%, transparent);
+}
+.am-hero__qr { cursor: zoom-in; }
 .am-card__foot {
   display: flex; align-items: center; justify-content: space-between;
   margin-top: .7rem; padding-top: .55rem; border-top: 1px solid var(--am-line);
@@ -166,6 +172,32 @@
   .am-card { animation: none; }
   .am-card:hover { transform: none; }
 }
+
+/* ---- QR lightbox (tap a small QR to enlarge it for scanning) ---- */
+.am-lightbox {
+  position: fixed; inset: 0; z-index: 1000; display: none;
+  place-items: center; padding: 1.5rem;
+  background: rgba(0, 0, 0, .74);
+}
+.am-lightbox.is-open { display: grid; animation: am-fade .15s ease; }
+.am-lightbox__panel {
+  position: relative; background: #fff; color: #111;
+  border-radius: 16px; padding: 1.2rem 1.2rem 1rem; text-align: center;
+  width: min(340px, 90vw); box-shadow: 0 24px 70px rgba(0, 0, 0, .5);
+}
+.am-lightbox__img {
+  width: 100%; max-width: 300px; height: auto; display: block; margin: 0 auto;
+  border-radius: 8px; image-rendering: pixelated;
+}
+.am-lightbox__cap { margin: .75rem 0 .1rem; font-weight: 700; font-size: .95rem; }
+.am-lightbox__hint { margin: 0; color: #555; font-size: .78rem; }
+.am-lightbox__close {
+  position: absolute; top: -2.6rem; right: 0; width: 2rem; height: 2rem;
+  border: 0; border-radius: 50%; background: rgba(255, 255, 255, .15);
+  color: #fff; font-size: 1.3rem; line-height: 1; cursor: pointer;
+}
+.am-lightbox__close:hover { background: rgba(255, 255, 255, .3); }
+@keyframes am-fade { from { opacity: 0; } }
 
 /* ---- Landing page ---- */
 .am-landing {

--- a/mapvalidator/catalog.py
+++ b/mapvalidator/catalog.py
@@ -265,6 +265,20 @@ def render_maps_page(
     cards = [_card_html(e, descriptions.get(e["slug"]) or {}) for e in ordered]
     out += ['<div class="am-grid">', *cards, "</div>"]
 
+    # Lightbox: tap a small QR to enlarge it for scanning.
+    out += [
+        "",
+        '<div class="am-lightbox" role="dialog" aria-modal="true" '
+        'aria-label="QR code">',
+        '  <button class="am-lightbox__close" aria-label="Close">&times;</button>',
+        '  <div class="am-lightbox__panel">',
+        '    <img class="am-lightbox__img" src="" alt="">',
+        '    <p class="am-lightbox__cap"></p>',
+        '    <p class="am-lightbox__hint">Scan with the ATAK device to install.</p>',
+        "  </div>",
+        "</div>",
+    ]
+
     if missing:
         out += [
             "",

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -97,6 +97,8 @@ def test_render_maps_page_card_html():
     assert "key required" in md  # needs_key badge
     # a Street filter chip is present
     assert '<button class="am-chip" data-cat="Street">Street</button>' in md
+    # the tap-to-enlarge QR lightbox is present
+    assert "am-lightbox" in md
 
 
 def test_iter_map_files_skips_dot_directories(tmp_path):


### PR DESCRIPTION
The per-map QR thumbnails were ~58px — too small/dense to scan. 

- **Site:** tap any QR (card or hero) to open a large, crisp, scannable lightbox with a caption; close on backdrop or Esc. Thumbnails bumped to 66px with a zoom-in cue. (Source QRs are 530px native, so the enlarged view is sharp.)
- **README:** GitHub strips JS, so no lightbox — enlarged the bundle QR from 160px to 240px so it scans directly.

Verified with a Playwright screenshot of the open lightbox; 157 tests pass; `mkdocs build --strict` clean.