### PR TITLE
ci: generate star history chart in CI instead of starchart.cc

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,0 +1,40 @@
+name: Star History
+
+# Renders the stargazers-over-time chart inside CI and commits the SVGs.
+# GitHub restricted the public stargazers endpoint on 2026-06-30, so hosted
+# services (starchart.cc, api.star-history.com) can no longer build this chart
+# for us. A workflow running in this repo still has stargazer access via the
+# default GITHUB_TOKEN, so we generate the chart here and embed a static file.
+
+on:
+  schedule:
+    - cron: "0 5 * * *" # daily, off-peak UTC
+  watch:
+    types: [started] # refresh right after a new star
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: star-history
+  cancel-in-progress: true # collapse a burst of stars into one run
+
+jobs:
+  star-history:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Pinned to the v1.0.4 commit: this action runs with contents: write.
+      - uses: narayann7/star-history-action@c2061675dacbf6f35d116e556015b8905843387f # v1.0.4
+        with:
+          repos: ${{ github.repository }}
+          output-dir: docs/images/star-history
+          # The default GITHUB_TOKEN should have stargazer access to this repo.
+          # If a run fails with 403/404 on the stargazers endpoint, add a
+          # fine-grained PAT (Metadata: read) as secret STARS_TOKEN, uncomment:
+          # token: ${{ secrets.STARS_TOKEN }}
+          # commit-message defaults to "chore: update star history [skip ci]",
+          # which keeps semantic-release and the other workflows out of the loop.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![ATAK-Maps Logo](https://github.com/joshuafuller/ATAK-Maps/blob/master/images/ATAK_MAPS_Logo.png?raw=true)
 
 [![Latest Release](https://img.shields.io/github/v/release/joshuafuller/ATAK-Maps?style=flat)](https://github.com/joshuafuller/ATAK-Maps/releases/latest) ![Release Date](https://img.shields.io/github/release-date/joshuafuller/ATAK-Maps?style=flat) [![Downloads](https://img.shields.io/github/downloads/joshuafuller/ATAK-Maps/total?style=flat)](https://github.com/joshuafuller/ATAK-Maps/releases/latest) [![XML Validation](https://img.shields.io/github/actions/workflow/status/joshuafuller/ATAK-Maps/validate-maps.yml?label=XML%20validation&style=flat)](https://github.com/joshuafuller/ATAK-Maps/actions/workflows/validate-maps.yml)
-[![Stars](https://img.shields.io/github/stars/joshuafuller/ATAK-Maps?style=flat)](https://github.com/joshuafuller/ATAK-Maps/stargazers) [![License](https://img.shields.io/github/license/joshuafuller/ATAK-Maps?style=flat)](LICENSE) [![Discord](https://img.shields.io/discord/698067185515495436?style=flat)](https://discord.gg/dQUYADMW87) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/joshuafuller/ATAK-Maps)
+[![Stars](https://img.shields.io/github/stars/joshuafuller/ATAK-Maps?style=flat)](https://github.com/joshuafuller/ATAK-Maps) [![License](https://img.shields.io/github/license/joshuafuller/ATAK-Maps?style=flat)](LICENSE) [![Discord](https://img.shields.io/discord/698067185515495436?style=flat)](https://discord.gg/dQUYADMW87) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/joshuafuller/ATAK-Maps)
 
 ## Detailed Overview of ATAK-Maps
 
@@ -110,6 +110,8 @@ For more details, including instructions for forks, see [docs/release-guide.md](
 ATAK-Maps is distributed under the [MIT License](LICENSE).
 
 ## Stargazers over time
-[![Stargazers over time](https://starchart.cc/joshuafuller/ATAK-Maps.svg?variant=adaptive)](https://starchart.cc/joshuafuller/ATAK-Maps)
+
+<!-- star-history:start -->
+<!-- star-history:end -->
 
 


### PR DESCRIPTION
Fixes #90

Replaces the dead `starchart.cc` embed with a chart generated inside this repo's CI and committed as a static SVG.

## Why

GitHub [restricted the stargazers endpoint](https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/) to admins and collaborators on 2026-06-30. Third-party chart services can no longer enumerate our stargazers, so the embed renders nothing. A workflow running *inside* this repo still has that access.

Uses [`narayann7/star-history-action`](https://github.com/narayann7/star-history-action), which vendors star-history's own renderer — [the approach star-history's maintainer points to](https://github.com/star-history/star-history/issues/539#issuecomment-4896077391) for people who would rather not hand a fine-grained PAT to their API. Pinned to commit `c206167` (v1.0.4) rather than `@v1`, since it runs with `contents: write`.

## Changes

- **`.github/workflows/star-history.yml`** — daily cron, `watch: started`, and manual dispatch. Writes to `docs/images/star-history/`. Commits with the action's default `chore: … [skip ci]` message, so it won't trigger semantic-release or reopen the master-tip race fixed in 330f36c.
- **`README.md`** — `starchart.cc` embed replaced with the action's marker comments; it fills in a `<picture>` block with light/dark variants.
- **`README.md` line 6** — stars badge repointed away from `/stargazers`, which now 404s anonymously (verified). The badge image is unaffected; the raw count stayed public.

## Verification note

The README's chart section is empty until the first workflow run — `workflow_dispatch` only becomes available once this is on `master`. The one untested assumption is whether Actions' `GITHUB_TOKEN` has stargazer access; testing locally used an owner PAT, which is a different principal. A commented `token: ${{ secrets.STARS_TOKEN }}` fallback is in place if the run 403s. Will report the actual run result.